### PR TITLE
When using models with a secondary database connection (e.g., mysql2)…

### DIFF
--- a/src/Datatable/DataFetcher.php
+++ b/src/Datatable/DataFetcher.php
@@ -63,7 +63,8 @@ class DataFetcher
 
         /** @var Model $modelInstance */
         $modelInstance = call_user_func([$this->resourceClass, 'make'])->getModelInstance();
-        $databaseColumns = Schema::getColumnListing($modelInstance->getTable());
+        $connectionName = $modelInstance->getConnectionName();
+        $databaseColumns = Schema::connection($connectionName)->getColumnListing($modelInstance->getTable());
 
         // 🔎 Apply search conditions
         if (!empty($search)) {
@@ -98,7 +99,7 @@ class DataFetcher
                 $query->orderBy($sortColumnName, $sortDirection);
             }
         }
-        
+
         return $query->paginate($perPage, 'page', $page);
     }
 }


### PR DESCRIPTION
…, search and sorting in Buildora datatables did not work correctly. This was caused by Schema::getColumnListing(...) defaulting to the primary database connection, which failed to retrieve the correct column list for the secondary database. The fix ensures the column listing uses the correct connection by calling Schema::connection($model->getConnectionName()).