### PR TITLE
✨ Add responsive columnSpan support to form fields

### DIFF
--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -34,7 +34,7 @@
                 @method('PUT')
             @endif
 
-            <div class="flex-1 space-y-6">
+            <div class="grid grid-cols-12 gap-6">
                 @foreach($fields as $field)
                     @if(!$field->isVisible('create') && !isset($item))
                         @continue
@@ -46,26 +46,36 @@
 
                     @php
                         $value = old($field->name, $item->{$field->name} ?? '');
+
+                        // Responsive column span support
+                        $colSpans = $field->getColumnSpan(); // always an array
+                        $colClasses = collect($colSpans)->map(
+                            fn($cols, $breakpoint) => $breakpoint === 'default'
+                                ? "col-span-{$cols}"
+                                : "{$breakpoint}:col-span-{$cols}"
+                        )->implode(' ');
                     @endphp
 
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 items-center">
-                        <label for="{{ $field->name }}" class="font-semibold text-gray-700 dark:text-gray-300">
+                    {{-- Force new row if requested --}}
+                    @if(method_exists($field, 'shouldStartNewRow') && $field->shouldStartNewRow())
+                        <div class="col-span-12"></div>
+                    @endif
+
+                    <div class="{{ $colClasses }}">
+                        <label for="{{ $field->name }}" class="block font-semibold text-gray-700 dark:text-gray-300 mb-1">
                             {{ $field->label }}
                         </label>
 
-                        <div class="col-span-2">
-                            @if(!$field instanceof \Ginkelsoft\Buildora\Fields\Types\ViewField)
-                                @component("buildora::components.input.{$field->type}", ['field' => $field, 'value' => $value])
-                                @endcomponent
-                            @else
-                                {!! $field->detailPage() !!}
-                            @endif
-                        </div>
+                        @if(!$field instanceof \Ginkelsoft\Buildora\Fields\Types\ViewField)
+                            @component("buildora::components.input.{$field->type}", ['field' => $field, 'value' => $value])
+                            @endcomponent
+                        @else
+                            {!! $field->detailPage() !!}
+                        @endif
                     </div>
                 @endforeach
             </div>
 
-            <!-- ✅ Sticky footer-knoppen -->
             <div class="flex justify-between mt-auto pt-6 border-t border-gray-200">
                 <x-buildora::button.back :model="$model"/>
                 <x-buildora::button.save/>

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -10,6 +10,8 @@ namespace Ginkelsoft\Buildora\Fields;
  */
 class Field
 {
+    protected bool $startNewRow = false;
+    protected array $columnSpan = ['default' => 12];
     protected bool $isSearchable = false;
     protected string $searchable;
     public string $name;
@@ -202,18 +204,41 @@ class Field
         return $this->helpText;
     }
 
-    // Shorthand methods for visibility toggles
+    public function columnSpan(int|array $value): static
+    {
+        if (is_array($value)) {
+            $this->columnSpan = $value;
+        } else {
+            $this->columnSpan = ['default' => $value];
+        }
+
+        return $this;
+    }
+
+    public function getColumnSpan(): array
+    {
+        return $this->columnSpan;
+    }
+
+    public function startNewRow(bool $value = true): static
+    {
+        $this->startNewRow = $value;
+        return $this;
+    }
+
+    public function shouldStartNewRow(): bool
+    {
+        return $this->startNewRow;
+    }
 
     public function showInTable(): self { return $this->show('table'); }
     public function showInCreate(): self { return $this->show('create'); }
     public function showInEdit(): self { return $this->show('edit'); }
-    public function showInDetail(): self { return $this->show('detail'); }
     public function showInExport(): self { return $this->show('export'); }
 
     public function hideFromTable(): self { return $this->hide('table'); }
     public function hideFromCreate(): self { return $this->hide('create'); }
     public function hideFromEdit(): self { return $this->hide('edit'); }
-    public function hideFromDetail(): self { return $this->hide('detail'); }
     public function hideFromExport(): self { return $this->hide('export'); }
 
     /**


### PR DESCRIPTION
Fields can now define responsive column widths using columnSpan([...]) with Tailwind-style breakpoints. 
Supports both integer and array input (e.g. columnSpan(6) or columnSpan(['default' => 12, 'md' => 6])).
Includes startNewRow() to force line breaks in grid layout.