### PR TITLE
Added Detail page

### DIFF
--- a/resources/views/show.blade.php
+++ b/resources/views/show.blade.php
@@ -1,0 +1,50 @@
+@extends('buildora::layouts.buildora')
+
+@section('content')
+
+    <h1 class="text-2xl font-bold mb-6 text-gray-900 dark:text-white">
+        {{ class_basename($item::class) }} #{{ $item->id }}
+    </h1>
+
+    <div class="grid grid-cols-12 gap-6">
+        @foreach($fields as $field)
+            @if(!$field->isVisible('detail'))
+                @continue
+            @endif
+
+            @php
+                $colSpansRaw = $field->getColumnSpan();
+                $colSpans = is_array($colSpansRaw) ? $colSpansRaw : ['default' => $colSpansRaw];
+                $colClasses = collect($colSpans)->map(
+                    fn($cols, $breakpoint) => $breakpoint === 'default'
+                        ? "col-span-{$cols}"
+                        : "{$breakpoint}:col-span-{$cols}"
+                )->implode(' ');
+            @endphp
+
+            @if(method_exists($field, 'shouldStartNewRow') && $field->shouldStartNewRow())
+                <div class="col-span-12"></div>
+            @endif
+
+            <div class="{{ $colClasses }}">
+                <div class="bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 h-full">
+                    <label class="block text-sm font-semibold text-gray-600 dark:text-gray-300 mb-1">
+                        {{ $field->label }}
+                    </label>
+
+                    <div class="text-gray-900 dark:text-gray-100 text-base">
+                        {!! $field instanceof \Ginkelsoft\Buildora\Fields\Types\ViewField
+                            ? $field->detailPage()
+                            : e($item->{$field->name})
+                        !!}
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mt-8">
+        <x-buildora::button.back :model="$model"/>
+    </div>
+
+@endsection

--- a/resources/views/wrapped-detail.blade.php
+++ b/resources/views/wrapped-detail.blade.php
@@ -1,0 +1,10 @@
+@extends('buildora::layouts.buildora')
+
+@section('content')
+    @include($view, [
+        'resource' => $resource,
+        'item' => $item,
+        'fields' => $fields,
+        'model' => $model,
+    ])
+@endsection

--- a/routes/buildora.php
+++ b/routes/buildora.php
@@ -97,6 +97,9 @@ Route::prefix(config('buildora.route_prefix', 'buildora'))
             Route::put('{resource}/{id}', [BuildoraController::class, 'update'])
                 ->name('buildora.update');
 
+            Route::get('{resource}/{id}', [BuildoraController::class, 'show'])
+                ->name('buildora.show');
+
             Route::delete('{resource}/{id}', [BuildoraController::class, 'destroy'])
                 ->name('buildora.destroy');
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -10,6 +10,8 @@ namespace Ginkelsoft\Buildora\Fields;
  */
 class Field
 {
+    protected bool $startNewRow = false;
+    protected array $columnSpan = ['default' => 12];
     protected bool $isSearchable = false;
     protected string $searchable;
     public string $name;
@@ -28,6 +30,7 @@ class Field
         'create' => true,
         'edit' => true,
         'export' => true,
+        'detail' => true,
     ];
 
     public mixed $value = null;
@@ -202,19 +205,44 @@ class Field
         return $this->helpText;
     }
 
-    // Shorthand methods for visibility toggles
+    public function columnSpan(int|array $value): static
+    {
+        if (is_array($value)) {
+            $this->columnSpan = $value;
+        } else {
+            $this->columnSpan = ['default' => $value];
+        }
+
+        return $this;
+    }
+
+    public function getColumnSpan(): array
+    {
+        return $this->columnSpan;
+    }
+
+    public function startNewRow(bool $value = true): static
+    {
+        $this->startNewRow = $value;
+        return $this;
+    }
+
+    public function shouldStartNewRow(): bool
+    {
+        return $this->startNewRow;
+    }
 
     public function showInTable(): self { return $this->show('table'); }
     public function showInCreate(): self { return $this->show('create'); }
     public function showInEdit(): self { return $this->show('edit'); }
-    public function showInDetail(): self { return $this->show('detail'); }
     public function showInExport(): self { return $this->show('export'); }
+    public function showInDetail(): self { return $this->show('detail'); }
 
     public function hideFromTable(): self { return $this->hide('table'); }
     public function hideFromCreate(): self { return $this->hide('create'); }
     public function hideFromEdit(): self { return $this->hide('edit'); }
-    public function hideFromDetail(): self { return $this->hide('detail'); }
     public function hideFromExport(): self { return $this->hide('export'); }
+    public function hideFromDetailt(): self { return $this->hide('detail'); }
 
     /**
      * Convert the field into an array representation.

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -232,17 +232,11 @@ class Field
         return $this->startNewRow;
     }
 
-    public function showInTable(): self { return $this->show('table'); }
-    public function showInCreate(): self { return $this->show('create'); }
-    public function showInEdit(): self { return $this->show('edit'); }
-    public function showInExport(): self { return $this->show('export'); }
-    public function showInDetail(): self { return $this->show('detail'); }
-
     public function hideFromTable(): self { return $this->hide('table'); }
     public function hideFromCreate(): self { return $this->hide('create'); }
     public function hideFromEdit(): self { return $this->hide('edit'); }
     public function hideFromExport(): self { return $this->hide('export'); }
-    public function hideFromDetailt(): self { return $this->hide('detail'); }
+    public function hideFromDetail(): self { return $this->hide('detail'); }
 
     /**
      * Convert the field into an array representation.

--- a/src/Http/Controllers/BuildoraController.php
+++ b/src/Http/Controllers/BuildoraController.php
@@ -175,16 +175,17 @@ class BuildoraController extends Controller
     public function show(string $model, int|string $id)
     {
         $resource = ResourceResolver::resolve($model);
-        $query = $resource::query();
-
-        $item = $query->findOrFail($id);
+        $item = $resource::query()->findOrFail($id);
         $resource->fill($item);
 
-        return view('buildora::show', [
+        $customView = $resource->getDetailView();
+
+        return view('buildora::wrapped-detail', [
             'resource' => $resource,
             'item' => $item,
             'fields' => $resource->getFields(),
             'model' => $model,
+            'view' => $customView ?? 'buildora::show',
         ]);
     }
 

--- a/src/Http/Controllers/BuildoraController.php
+++ b/src/Http/Controllers/BuildoraController.php
@@ -172,6 +172,22 @@ class BuildoraController extends Controller
             ->with('success', ucfirst($model) . ' updated successfully.');
     }
 
+    public function show(string $model, int|string $id)
+    {
+        $resource = ResourceResolver::resolve($model);
+        $query = $resource::query();
+
+        $item = $query->findOrFail($id);
+        $resource->fill($item);
+
+        return view('buildora::show', [
+            'resource' => $resource,
+            'item' => $item,
+            'fields' => $resource->getFields(),
+            'model' => $model,
+        ]);
+    }
+
     /**
      * Delete a resource instance.
      *

--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -15,6 +15,7 @@ abstract class BuildoraResource
 {
     protected string $modelClass;
     protected array $fields;
+    protected ?string $detailView = null;
 
     /**
      * BuildoraResource constructor.
@@ -173,5 +174,16 @@ abstract class BuildoraResource
     public static function query(): \Ginkelsoft\Buildora\BuildoraQueryBuilder
     {
         return QueryFactory::make(new static());
+    }
+
+    public function setDetailView(string $view): static
+    {
+        $this->detailView = $view;
+        return $this;
+    }
+
+    public function getDetailView(): ?string
+    {
+        return $this->detailView;
     }
 }


### PR DESCRIPTION
- Introduced `setDetailView()` and `getDetailView()` in BuildoraResource
- `BuildoraController@show()` now loads a single wrapper view (`buildora::pages.wrapped-detail`)
- Wrapper view loads either the default or a custom detail partial (via @include)
- Ensures all detail pages remain inside the main Buildora layout
- Enables per-resource customization of detail views without layout duplication