### PR TITLE
Fix email address label

### DIFF
--- a/resources/lang/en/buildora.php
+++ b/resources/lang/en/buildora.php
@@ -3,7 +3,7 @@
 return [
     'Welcome' => 'Welcome',
     'Log in to continue' => 'Log in to continue',
-    'E-mailaddress' => 'E-mailadress',
+    'E-mailaddress' => 'E-mail address',
     'Password' => 'Password',
     'Forgot your password?' => 'Forgot your password?',
     'Login' => 'Login',


### PR DESCRIPTION
## Summary
- fix typo for email address in English translation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684813b98e0c83238539f042d441126c