### PR TITLE
Use unified validation rules

### DIFF
--- a/src/Http/Controllers/BuildoraController.php
+++ b/src/Http/Controllers/BuildoraController.php
@@ -49,10 +49,7 @@ class BuildoraController extends Controller
             ->map(fn($field) => $field->getStoreColumn())
             ->toArray();
 
-        $validationRules = $resolvedFields
-            ->mapWithKeys(fn($field) => [$field->name => $field->getValidationRules($modelInstance)])
-            ->filter()
-            ->toArray();
+        $validationRules = $this->buildValidationRules($resolvedFields, $request);
 
         $validatedData = $request->validate($validationRules);
 
@@ -125,10 +122,7 @@ class BuildoraController extends Controller
             ->map(fn($field) => $field->getStoreColumn())
             ->toArray();
 
-        $validationRules = $resolvedFields
-            ->mapWithKeys(fn($field) => [$field->name => $field->getValidationRules($item)])
-            ->filter()
-            ->toArray();
+        $validationRules = $this->buildValidationRules($resolvedFields, $request);
 
         $validatedData = $request->validate($validationRules);
         $allowedRequestData = $request->only($storeColumns);


### PR DESCRIPTION
## Summary
- adopt `buildValidationRules` helper in controller
- remove duplicated `mapWithKeys` validation logic

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481aa0ac908323b52536539852d0b3