### PR TITLE
Fix repeatable field name binding

### DIFF
--- a/resources/js/buildora.js
+++ b/resources/js/buildora.js
@@ -6,3 +6,23 @@ window.Alpine = Alpine;
 Alpine.start();
 
 console.log("Alpine.js loaded!");
+
+function updateRepeatableFieldNames(form) {
+    form.querySelectorAll('[data-repeatable-index]').forEach((row) => {
+        const index = row.dataset.repeatableIndex;
+        row.querySelectorAll('[name]').forEach((el) => {
+            if (el.name && el.name.includes('${index}')) {
+                el.name = el.name.replaceAll('${index}', index);
+            }
+        });
+    });
+}
+
+window.updateRepeatableFieldNames = updateRepeatableFieldNames;
+
+document.addEventListener('submit', (e) => {
+    const form = e.target.closest('form');
+    if (form) {
+        updateRepeatableFieldNames(form);
+    }
+}, true);

--- a/resources/views/components/input/repeatable.blade.php
+++ b/resources/views/components/input/repeatable.blade.php
@@ -15,7 +15,13 @@
         class="space-y-6"
 >
     <template x-for="(row, index) in rows" :key="index">
-        <div class="relative bg-white border border-gray-200 rounded-lg shadow-sm p-6 space-y-4">
+        <div class="relative bg-white border border-gray-200 rounded-lg shadow-sm p-6 space-y-4"
+             x-bind:data-repeatable-index="index"
+             x-effect="$el.querySelectorAll('[name]').forEach(el => {
+                 if (el.name && el.name.includes('\${index}')) {
+                     el.name = el.name.replaceAll('\${index}', index);
+                 }
+             })">
             <button type="button"
                     @click="removeRow(index)"
                     class="absolute top-3 right-3 text-gray-400 hover:text-red-600"


### PR DESCRIPTION
## Summary
- update repeatable field markup so each row records its index
- add Alpine effect to replace `${index}` placeholders
- add helper script to ensure repeatable names are set before submit

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481a9f5f68832380f1172956a84c70