### PR TITLE
perf(buildora): add automatic eager loading for panel relations in Qu…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "extra": {
-        "buildora-version": "1.0.26",
+        "buildora-version": "1.0.27",
         "laravel": {
             "providers": [
                 "Ginkelsoft\\Buildora\\Providers\\BuildoraServiceProvider"

--- a/src/Layouts/Panel.php
+++ b/src/Layouts/Panel.php
@@ -34,7 +34,19 @@ class Panel
 
     public function usingModel(object $model): static
     {
-        $this->resourceClass = ResourceResolver::resolveFromMethod($model, $this->relationName)::class;
+        // Alleen bepalen WELKE resourceclass hoort bij de relatie, geen data ophalen
+        $relation = $model->{$this->relationName}();
+        $relatedModel = $relation->getRelated();
+        $base = class_basename($relatedModel);
+
+        $resourceClass = "App\\Buildora\\Resources\\{$base}Buildora";
+
+        if (!class_exists($resourceClass)) {
+            throw new \Exception("Buildora resource [{$resourceClass}] not found.");
+        }
+
+        $this->resourceClass = $resourceClass;
+
         return $this;
     }
 

--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -276,4 +276,20 @@ abstract class BuildoraResource
     {
         return strtolower(str_replace('Buildora', '', class_basename(static::class)));
     }
+
+    public function loadWithRelations(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
+    {
+        $relations = collect($this->getRelationResources())
+            ->pluck('relationName')
+            ->filter()
+            ->unique()
+            ->values()
+            ->toArray();
+
+        if (!empty($relations)) {
+            $query->with($relations);
+        }
+
+        return $query;
+    }
 }

--- a/src/Resources/QueryFactory.php
+++ b/src/Resources/QueryFactory.php
@@ -3,12 +3,12 @@
 namespace Ginkelsoft\Buildora\Resources;
 
 use Ginkelsoft\Buildora\BuildoraQueryBuilder;
-use Ginkelsoft\Buildora\Resources\BuildoraResource;
 
 /**
  * Class QueryFactory
  *
- * Factory to create a BuildoraQueryBuilder for a given resource.
+ * Factory to create a BuildoraQueryBuilder for a given resource,
+ * automatically eager-loading defined panel relations.
  */
 class QueryFactory
 {
@@ -20,7 +20,23 @@ class QueryFactory
      */
     public static function make(BuildoraResource $resource): BuildoraQueryBuilder
     {
+        // Maak de basisquery voor het model van deze resource
         $query = $resource->getModelInstance()->newQuery();
+
+        // ✅ Automatisch eager loaden van relaties uit definePanels()
+        if (method_exists($resource, 'getRelationResources')) {
+            $relations = collect($resource->getRelationResources())
+                ->pluck('relationName')
+                ->filter()
+                ->unique()
+                ->values()
+                ->toArray();
+
+            if (!empty($relations)) {
+                $query->with($relations);
+            }
+        }
+
         return new BuildoraQueryBuilder($query, $resource::class);
     }
 }


### PR DESCRIPTION
…eryFactory

Automatically eager-loads all defined panel relations (from `definePanels()`) when building a resource query. This prevents N+1 queries and significantly improves performance when rendering relation panels.

Changes:
- Updated QueryFactory::make() to include $query->with([...]) for all panels.
- Panels defined via Panel::relation() now load data in a single query.
- No manual loadWithRelations() calls required anymore.