### PR TITLE
perf(controller): optimize and document RelationDatatableController

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "extra": {
-        "buildora-version": "1.0.27",
+        "buildora-version": "1.0.28",
         "laravel": {
             "providers": [
                 "Ginkelsoft\\Buildora\\Providers\\BuildoraServiceProvider"


### PR DESCRIPTION
- Removed redundant first() call that previously triggered an extra SQL query for relation datatables.
- Added automatic eager loading of nested relations defined in the related Buildora resource (prevents N+1 issues in relation panels).
- Cleaned and refactored the controller for clarity and consistency.
- Added complete English PHPDoc blocks describing each step and the overall purpose of the controller (resolving resources, validating relations, building queries, eager loading, and returning JSON datatable data).
- Improved maintainability and performance of all Buildora relation panels.