### PR TITLE
fix(datatable): prevent duplicate data fetch on initialization

### DIFF
--- a/resources/views/components/datatable.blade.php
+++ b/resources/views/components/datatable.blade.php
@@ -3,7 +3,7 @@
     'componentKey' => Str::random(8)
 ])
 
-<div x-data="dataTable({{ json_encode($endpoint) }})" x-init="init()" class="mx-auto" :key="{{ json_encode($componentKey) }}">
+<div x-data="dataTable({{ json_encode($endpoint) }})" class="mx-auto" :key="{{ json_encode($componentKey) }}">
     <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
         <!-- 🔎 Zoekbalk -->
         <div class="relative w-full max-w-sm">


### PR DESCRIPTION
Remove redundant x-init directive that caused the init() method to be called twice - once automatically by Alpine.js when the component initializes, and once explicitly via x-init.

This eliminates duplicate HTTP requests on initial datatable load, improving performance and reducing unnecessary server load.
