### PR TITLE
fix(datatable): prevent duplicate data fetch on initialization

### DIFF
--- a/resources/views/components/datatable.blade.php
+++ b/resources/views/components/datatable.blade.php
@@ -3,7 +3,7 @@
     'componentKey' => Str::random(8)
 ])
 
-<div x-data="dataTable({{ json_encode($endpoint) }})" x-init="init()" class="mx-auto" :key="{{ json_encode($componentKey) }}">
+<div x-data="dataTable({{ json_encode($endpoint) }})" class="mx-auto" :key="{{ json_encode($componentKey) }}">
     <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
         <!-- 🔎 Zoekbalk -->
         <div class="relative w-full max-w-sm">
@@ -164,8 +164,12 @@
             selectedBulkAction: '',
             bulkActions: [],
             isLoading: false,
+            _initialized: false,
 
             init() {
+                if (this._initialized) return;
+                this._initialized = true;
+
                 this.debouncedFetchData = debounce(() => {
                     this.fetchData();
                 }, 300);


### PR DESCRIPTION
Add initialization guard flag to prevent init() method from being called multiple times. The guard ensures that even if Alpine.js calls init() more than once, the actual data fetch only happens once during component lifecycle.

This eliminates duplicate HTTP requests on initial datatable load, improving performance and reducing unnecessary server load.