### PR TITLE
 refactor(datatable): revert to simpler pagination implementation

### DIFF
--- a/config/buildora.php
+++ b/config/buildora.php
@@ -62,7 +62,6 @@ return [
     'datatable' => [
         'pagination' => [10, 25, 50, 100, 250],     // Available rows-per-page options
         'default_per_page' => 25,                   // Default selected pagination size
-        'pagination_strategy' => env('BUILDORA_PAGINATION_STRATEGY', 'length_aware'), // length_aware|simple
     ],
 
     /*

--- a/src/Buildora.php
+++ b/src/Buildora.php
@@ -22,7 +22,7 @@ class Buildora
      */
     public static function css()
     {
-        if (($light = @file_get_contents(__DIR__ . '/../dist/assets/style.css')) === false) {
+        if (($light = @file_get_contents(__DIR__.'/../dist/assets/style.css')) === false) {
             throw new BuildoraException('Unable to load the Buildora dashboard CSS.');
         }
 
@@ -30,7 +30,8 @@ class Buildora
 
         if ($theme == true) {
             $theme = '<style>' . $theme . '</style>';
-        } else {
+        }
+        else {
             $theme = '';
         }
 
@@ -47,7 +48,7 @@ class Buildora
      */
     public static function js()
     {
-        if (($js = @file_get_contents(__DIR__ . '/../dist/assets/app.js')) === false) {
+        if (($js = @file_get_contents(__DIR__.'/../dist/assets/app.js')) === false) {
             throw new BuildoraException('Unable to load the Buildora dashboard JavaScript.');
         }
 

--- a/src/Commands/BuildoraSyncPermissionsCommand.php
+++ b/src/Commands/BuildoraSyncPermissionsCommand.php
@@ -63,9 +63,7 @@ class BuildoraSyncPermissionsCommand extends Command
                     $generatedLabel = ucfirst($action) . ' ' . str_replace('_', ' ', str($modelName)->headline());
                     $permission->label = $generatedLabel;
                     $permission->save();
-                    $this->line(
-                        "✓ Registered: <comment>$permissionName</comment> with label <info>$generatedLabel</info>"
-                    );
+                    $this->line("✓ Registered: <comment>$permissionName</comment> with label <info>$generatedLabel</info>");
                 } else {
                     $this->line("✓ Registered: <comment>$permissionName</comment>");
                 }

--- a/src/Commands/GeneratePermissionsCommand.php
+++ b/src/Commands/GeneratePermissionsCommand.php
@@ -17,9 +17,7 @@ class GeneratePermissionsCommand extends Command
     public function handle(): void
     {
         if (! class_exists(\Spatie\Permission\Models\Permission::class)) {
-            $this->error(
-                'Spatie Permissions package is not installed. Please run: composer require spatie/laravel-permission'
-            );
+            $this->error('Spatie Permissions package is not installed. Please run: composer require spatie/laravel-permission');
             return;
         }
 
@@ -31,7 +29,8 @@ class GeneratePermissionsCommand extends Command
         $resources = collect(get_declared_classes())
             ->filter(fn ($class) =>
                 is_subclass_of($class, BuildoraResource::class)
-                && !(new ReflectionClass($class))->isAbstract());
+                && !(new ReflectionClass($class))->isAbstract()
+            );
 
         if ($resources->isEmpty()) {
             $this->warn('No Buildora resources found.');
@@ -39,6 +38,7 @@ class GeneratePermissionsCommand extends Command
         }
 
         foreach ($resources as $resourceClass) {
+
             $resource = new $resourceClass();
             $resourceName = $resource->uriKey();
 

--- a/src/Commands/MakeBuildoraResource.php
+++ b/src/Commands/MakeBuildoraResource.php
@@ -39,7 +39,7 @@ class MakeBuildoraResource extends Command
         }
 
         $fields = $this->generateFieldsArray($modelClass);
-        $relations = $this->detectModelRelations(new $modelClass());
+        $relations = $this->detectModelRelations(new $modelClass);
 
         $stub = <<<PHP
 <?php
@@ -122,7 +122,7 @@ PHP;
 
     private function generateFieldsArray(string $modelClass): string
     {
-        $modelInstance = new $modelClass();
+        $modelInstance = new $modelClass;
         $fillable = $modelInstance->getFillable();
         $primaryKey = $modelInstance->getKeyName();
         $fields = [];
@@ -144,8 +144,7 @@ PHP;
             }
         }
 
-        return '[' . PHP_EOL . '            ' .
-            implode(',' . PHP_EOL . '            ', $fields) . PHP_EOL . '        ]';
+        return '[' . PHP_EOL . '            ' . implode(',' . PHP_EOL . '            ', $fields) . PHP_EOL . '        ]';
     }
 
     private function resolveFieldType(string $field, object $model): string

--- a/src/Datatable/BuildoraDatatable.php
+++ b/src/Datatable/BuildoraDatatable.php
@@ -21,7 +21,6 @@ class BuildoraDatatable
     protected bool $isRelationMode = false;
 
     protected BuildoraResource $resource;
-    protected string $paginationStrategy;
 
     public function __construct(BuildoraResource|string $resource)
     {
@@ -31,7 +30,6 @@ class BuildoraDatatable
 
         // Alleen kolommen bouwen, geen fetch!
         $this->columns = ColumnBuilder::build($this->resource);
-        $this->paginationStrategy = Config::get('buildora.datatable.pagination_strategy', 'length_aware');
     }
 
     public static function fromRelation(Relation $relation, BuildoraResource $resource): self
@@ -44,35 +42,30 @@ class BuildoraDatatable
 
     public function fetchDataUsingRelation(Relation $relation): void
     {
-        $perPage = (int) Request::input('per_page', Config::get('buildora.datatable.default_per_page'));
-        if ($perPage < 1) {
-            $perPage = (int) Config::get('buildora.datatable.default_per_page', 25);
-        }
-        $page = (int) Request::input('page', 1);
+        $perPage = Request::input('per_page', Config::get('buildora.datatable.default_per_page'));
+        $page = Request::input('page', 1);
 
-        // ✅ PERFORMANCE: Select only columns needed for table display
-        $selectColumns = $this->getSelectColumnsForRelation($relation);
+        $paginator = $relation->paginate($perPage, ['*'], 'page', $page);
 
-        $paginator = $this->paginationStrategy === 'simple'
-            ? $relation->select($selectColumns)->simplePaginate($perPage)
-            : $relation->select($selectColumns)->paginate($perPage, ['*'], 'page', $page);
-
-        // ✅ OPTIMIZATION 5: Reuse resource fields instead of cloning entire resource
-        $this->data = $this->formatRecords($paginator->items());
+        $this->data = array_map(function ($record) {
+            $resource = clone $this->resource;
+            $resource->fill($record);
+            return RowFormatter::format($resource, $this->resource);
+        }, $paginator->items());
 
         $this->columns = ColumnBuilder::build($this->resource);
         $this->initialized = true;
 
-        $this->pagination = $this->buildPaginationMeta($paginator, $perPage, $page);
+        $this->pagination = [
+            'total' => $paginator->total(),
+            'per_page' => $paginator->perPage(),
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+        ];
     }
 
-    protected function initialize(
-        string $search = '',
-        string $sortBy = '',
-        string $sortDirection = 'asc',
-        int $perPage = null,
-        int $page = 1
-    ): void {
+    protected function initialize(string $search = '', string $sortBy = '', string $sortDirection = 'asc', int $perPage = null, int $page = 1): void
+    {
         if ($this->initialized || $this->isRelationMode) {
             return;
         }
@@ -81,27 +74,24 @@ class BuildoraDatatable
         $this->initialized = true;
     }
 
-    protected function fetchData(
-        string $search = '',
-        string $sortBy = '',
-        string $sortDirection = 'asc',
-        int $perPage = null,
-        int $page = 1
-    ): void {
-        $perPage = (int) ($perPage ?? Request::input('per_page', Config::get('buildora.datatable.default_per_page')));
-        if ($perPage < 1) {
-            $perPage = (int) Config::get('buildora.datatable.default_per_page', 25);
-        }
-        $page = (int) Request::input('page', $page);
+    protected function fetchData(string $search = '', string $sortBy = '', string $sortDirection = 'asc', int $perPage = null, int $page = 1): void
+    {
+        $perPage = $perPage ?? Request::input('per_page', Config::get('buildora.datatable.default_per_page'));
+        $page = Request::input('page', $page);
 
         $fields = $this->resource->resolveFields($this->resource->getModelInstance());
         $fetcher = new DataFetcher(get_class($this->resource), $fields);
         $paginator = $fetcher->fetch($search, $sortBy, $sortDirection, $perPage, $page);
 
-        // ✅ OPTIMIZATION 5: Use optimized record formatting
-        $this->data = $this->formatRecords($paginator->items());
+        $formattedRows = array_map(fn($r) => RowFormatter::format($r, $this->resource), $paginator->items());
 
-        $this->pagination = $this->buildPaginationMeta($paginator, $perPage, $page);
+        $this->data = $formattedRows;
+        $this->pagination = [
+            'total' => $paginator->total(),
+            'per_page' => $paginator->perPage(),
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+        ];
     }
 
     public function getColumns(): array
@@ -109,13 +99,8 @@ class BuildoraDatatable
         return $this->columns;
     }
 
-    public function getJsonResponse(
-        string $search = '',
-        string $sortBy = '',
-        string $sortDirection = 'asc',
-        int $perPage = null,
-        int $page = 1
-    ): array {
+    public function getJsonResponse(string $search = '', string $sortBy = '', string $sortDirection = 'asc', int $perPage = null, int $page = 1): array
+    {
         $page = Request::input('page', $page);
         $perPage = Request::input('per_page', Config::get('buildora.datatable.default_per_page'));
 
@@ -137,92 +122,5 @@ class BuildoraDatatable
         }
 
         return $this->getColumns();
-    }
-
-    /**
-     * Get columns to select for relation queries (only table-visible fields).
-     *
-     * @param Relation $relation
-     * @return array
-     */
-    protected function getSelectColumnsForRelation(Relation $relation): array
-    {
-        $table = $relation->getRelated()->getTable();
-        $columns = ["{$table}.*"]; // Fallback to all columns
-        $selectColumns = [];
-
-        foreach ($this->resource->getFields() as $field) {
-            // Only process fields visible in table
-            if (!($field->visibility['table'] ?? false)) {
-                continue;
-            }
-
-            // For BelongsTo, we need the foreign key
-            if ($field instanceof \Ginkelsoft\Buildora\Fields\Types\BelongsToField) {
-                continue; // Will be eager loaded
-            }
-
-            $selectColumns[] = $field->name;
-        }
-
-        // Always include id and timestamps
-        $finalColumns = array_unique(array_merge(
-            ["{$table}.id", "{$table}.created_at", "{$table}.updated_at"],
-            array_map(fn($col) => "{$table}.{$col}", $selectColumns)
-        ));
-
-        return !empty($selectColumns) ? $finalColumns : ["{$table}.*"];
-    }
-
-    /**
-     * Format records efficiently with minimal resource cloning.
-     *
-     * @param array $records
-     * @return array
-     */
-    protected function formatRecords(array $records): array
-    {
-        $rowActionDefinitions = method_exists($this->resource, 'defineRowActions')
-            ? $this->resource->defineRowActions()
-            : [];
-
-        $formatted = [];
-        foreach ($records as $record) {
-            $this->resource->fill($record);
-            $formatted[] = RowFormatter::format($this->resource, $this->resource, $rowActionDefinitions);
-        }
-
-        return $formatted;
-    }
-
-    protected function buildPaginationMeta($paginator, int $perPage, int $fallbackPage = 1): array
-    {
-        $currentPage = method_exists($paginator, 'currentPage')
-            ? (int) $paginator->currentPage()
-            : max(1, $fallbackPage);
-
-        $perPage = method_exists($paginator, 'perPage')
-            ? (int) $paginator->perPage()
-            : max(1, $perPage);
-
-        $total = method_exists($paginator, 'total')
-            ? (int) $paginator->total()
-            : null;
-
-        $hasMore = method_exists($paginator, 'hasMorePages')
-            ? (bool) $paginator->hasMorePages()
-            : ($total !== null ? $currentPage * $perPage < $total : false);
-
-        $lastPage = method_exists($paginator, 'lastPage')
-            ? (int) $paginator->lastPage()
-            : ($hasMore ? $currentPage + 1 : $currentPage);
-
-        return [
-            'total' => $total,
-            'per_page' => $perPage,
-            'current_page' => max(1, $currentPage),
-            'last_page' => max(1, $lastPage),
-            'has_more' => $hasMore,
-        ];
     }
 }

--- a/src/Datatable/DataFetcher.php
+++ b/src/Datatable/DataFetcher.php
@@ -2,13 +2,11 @@
 
 namespace Ginkelsoft\Buildora\Datatable;
 
-use Ginkelsoft\Buildora\Support\SchemaCache;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Ginkelsoft\Buildora\Fields\Field;
-use Ginkelsoft\Buildora\Fields\Types\BelongsToField;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Config;
 
 /**
  * Class DataFetcher
@@ -51,7 +49,7 @@ class DataFetcher
      * @param string $sortDirection The sort direction (asc|desc).
      * @param int $perPage The number of items per page.
      * @param int $page The current page.
-     * @return PaginatorContract The paginated result set.
+     * @return LengthAwarePaginator The paginated result set.
      */
     public function fetch(
         string $search = '',
@@ -59,65 +57,18 @@ class DataFetcher
         string $sortDirection = 'asc',
         int $perPage = 25,
         int $page = 1
-    ): PaginatorContract {
+    ): LengthAwarePaginator {
         /** @var Builder $query */
         $query = call_user_func([$this->resourceClass, 'query']);
 
         /** @var Model $modelInstance */
         $modelInstance = call_user_func([$this->resourceClass, 'make'])->getModelInstance();
         $connectionName = $modelInstance->getConnectionName();
+        $databaseColumns = Schema::connection($connectionName)->getColumnListing($modelInstance->getTable());
 
-        // ✅ OPTIMIZATION 1: Use cached schema instead of querying database
-        $databaseColumns = SchemaCache::getColumnListing($modelInstance->getTable(), $connectionName);
-
-        // ✅ OPTIMIZATION 2: Select only table-visible columns + id
-        $visibleColumns = $this->getVisibleTableColumns($modelInstance->getTable(), $databaseColumns);
-        if (!empty($visibleColumns)) {
-            $query->select($visibleColumns);
-        }
-
-        // ✅ OPTIMIZATION 3: Auto eager-load BelongsTo relations to prevent N+1
-        $this->eagerLoadBelongsToRelations($query);
-
-        // 🔎 OPTIMIZATION 4: Apply search conditions with optimized joins
+        // 🔎 Apply search conditions
         if (!empty($search)) {
-            $relationsToJoin = [];
-
-            // First pass: identify which relations need joins
-            foreach ($this->columns as $field) {
-                if (! $field instanceof Field || ! $field->isSearchable()) {
-                    continue;
-                }
-
-                $column = $field->getSearchColumn();
-                if (str_contains($column, '.')) {
-                    [$relation, $relColumn] = explode('.', $column, 2);
-                    if (!isset($relationsToJoin[$relation])) {
-                        $relationsToJoin[$relation] = [];
-                    }
-                    $relationsToJoin[$relation][] = $relColumn;
-                }
-            }
-
-            // Apply joins for relation searches (more efficient than whereHas)
-            foreach ($relationsToJoin as $relation => $columns) {
-                if (method_exists($modelInstance, $relation)) {
-                    $relationInstance = $modelInstance->{$relation}();
-                    $relatedTable = $relationInstance->getRelated()->getTable();
-                    $foreignKey = $relationInstance->getForeignKeyName();
-                    $ownerKey = $relationInstance->getOwnerKeyName();
-
-                    $query->leftJoin(
-                        $relatedTable,
-                        "{$modelInstance->getTable()}.{$foreignKey}",
-                        '=',
-                        "{$relatedTable}.{$ownerKey}"
-                    );
-                }
-            }
-
-            // Apply search conditions
-            $query->where(function (Builder $q) use ($search, $databaseColumns, $relationsToJoin, $modelInstance) {
+            $query->where(function (Builder $q) use ($search, $databaseColumns) {
                 foreach ($this->columns as $field) {
                     if (! $field instanceof Field || ! $field->isSearchable()) {
                         continue;
@@ -127,100 +78,28 @@ class DataFetcher
 
                     if (str_contains($column, '.')) {
                         [$relation, $relColumn] = explode('.', $column, 2);
-                        if (isset($relationsToJoin[$relation])) {
-                            $relationInstance = $modelInstance->{$relation}();
-                            $relatedTable = $relationInstance->getRelated()->getTable();
-                            $q->orWhere("{$relatedTable}.{$relColumn}", 'like', "%{$search}%");
-                        }
+                        $q->orWhereHas($relation, fn ($sub) => $sub->where($relColumn, 'like', "%{$search}%"));
                     } elseif (in_array($column, $databaseColumns)) {
-                        $q->orWhere("{$modelInstance->getTable()}.{$column}", 'like', "%{$search}%");
+                        $q->orWhere($column, 'like', "%{$search}%");
                     }
                 }
             });
-
-            // Ensure we only get distinct results after joins
-            $query->distinct();
         }
 
-        // ✅ OPTIMIZATION 5: Qualified column names for sorting
         if (!empty($sortBy)) {
             $sortColumn = collect($this->columns)->first(fn ($col) =>
-                (is_array($col) ? ($col['name'] ?? null) : $col) === $sortBy);
+                (is_array($col) ? ($col['name'] ?? null) : $col) === $sortBy
+            );
 
             $sortColumnName = is_array($sortColumn)
                 ? ($sortColumn['search_column'] ?? $sortColumn['name'] ?? null)
                 : $sortBy;
 
             if (in_array($sortColumnName, $databaseColumns)) {
-                // Use qualified column name to avoid ambiguity with joins
-                $query->orderBy("{$modelInstance->getTable()}.{$sortColumnName}", $sortDirection);
+                $query->orderBy($sortColumnName, $sortDirection);
             }
         }
 
-        $strategy = Config::get('buildora.datatable.pagination_strategy', 'length_aware');
-
-        return $strategy === 'simple'
-            ? $query->simplePaginate($perPage, ['*'], 'page')
-            : $query->paginate($perPage, ['*'], 'page', $page);
-    }
-
-    /**
-     * Get only columns that are visible in the table view.
-     *
-     * @param string $tableName
-     * @param array $databaseColumns
-     * @return array
-     */
-    protected function getVisibleTableColumns(string $tableName, array $databaseColumns): array
-    {
-        $columns = ["{$tableName}.*"]; // Always include primary key and timestamps
-        $selectedColumns = [];
-
-        foreach ($this->columns as $field) {
-            if (! $field instanceof Field) {
-                continue;
-            }
-
-            // Only include fields visible in table
-            if ($field->visibility['table'] ?? false) {
-                $columnName = $field->name;
-
-                // For BelongsTo fields, we need the foreign key column
-                if ($field instanceof BelongsToField) {
-                    // BelongsTo typically stores foreign_key, not the relation name
-                    // We'll need to keep all columns for relations
-                    continue;
-                }
-
-                if (in_array($columnName, $databaseColumns)) {
-                    $selectedColumns[] = "{$tableName}.{$columnName}";
-                }
-            }
-        }
-
-        // If we have specific columns, use them, otherwise select all
-        return !empty($selectedColumns) ? array_merge(["{$tableName}.id"], array_unique($selectedColumns)) : ["{$tableName}.*"];
-    }
-
-    /**
-     * Automatically eager-load all BelongsTo relations from columns to prevent N+1 queries.
-     *
-     * @param Builder $query
-     * @return void
-     */
-    protected function eagerLoadBelongsToRelations(Builder $query): void
-    {
-        $relations = [];
-
-        foreach ($this->columns as $field) {
-            if ($field instanceof BelongsToField) {
-                // BelongsTo field name is usually the relation method name
-                $relations[] = $field->name;
-            }
-        }
-
-        if (!empty($relations)) {
-            $query->with($relations);
-        }
+        return $query->paginate($perPage, 'page', $page);
     }
 }

--- a/src/Exports/ExportManager.php
+++ b/src/Exports/ExportManager.php
@@ -52,14 +52,12 @@ class ExportManager
                 })->toArray();
         });
 
-        return new class ($headers, $rows->toArray(), ucfirst($modelSlug)) implements FromArray, WithHeadings, WithTitle
-        {
+        return new class($headers, $rows->toArray(), ucfirst($modelSlug)) implements FromArray, WithHeadings, WithTitle {
             public function __construct(
                 protected array $headings,
                 protected array $rows,
                 protected string $title
-            ) {
-            }
+            ) {}
 
             /**
              * Return the rows as an array for export.

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -131,50 +131,35 @@ class Field
      *
      * @return self
      */
-    public function hideFromTable(): self
-    {
-        return $this->hide('table');
-    }
+    public function hideFromTable(): self { return $this->hide('table'); }
 
     /**
      * Hide the field from the create form.
      *
      * @return self
      */
-    public function hideFromCreate(): self
-    {
-        return $this->hide('create');
-    }
+    public function hideFromCreate(): self { return $this->hide('create'); }
 
     /**
      * Hide the field from the edit form.
      *
      * @return self
      */
-    public function hideFromEdit(): self
-    {
-        return $this->hide('edit');
-    }
+    public function hideFromEdit(): self { return $this->hide('edit'); }
 
     /**
      * Hide the field from export output.
      *
      * @return self
      */
-    public function hideFromExport(): self
-    {
-        return $this->hide('export');
-    }
+    public function hideFromExport(): self { return $this->hide('export'); }
 
     /**
      * Hide the field from the detail view.
      *
      * @return self
      */
-    public function hideFromDetail(): self
-    {
-        return $this->hide('detail');
-    }
+    public function hideFromDetail(): self { return $this->hide('detail'); }
 
     /**
      * Convert the field into an array representation.
@@ -197,3 +182,4 @@ class Field
         ];
     }
 }
+

--- a/src/Fields/Traits/HasLayout.php
+++ b/src/Fields/Traits/HasLayout.php
@@ -71,3 +71,4 @@ trait HasLayout
         return $this->startNewRow;
     }
 }
+

--- a/src/Fields/Traits/HasSearch.php
+++ b/src/Fields/Traits/HasSearch.php
@@ -74,3 +74,4 @@ trait HasSearch
         return true;
     }
 }
+

--- a/src/Fields/Traits/HasValidation.php
+++ b/src/Fields/Traits/HasValidation.php
@@ -47,3 +47,4 @@ trait HasValidation
         return $this->validationRules ?? [];
     }
 }
+

--- a/src/Fields/Traits/HasVisibility.php
+++ b/src/Fields/Traits/HasVisibility.php
@@ -61,3 +61,4 @@ trait HasVisibility
         return $this->visibility[$context] ?? false;
     }
 }
+

--- a/src/Fields/Types/AsyncBelongsToField.php
+++ b/src/Fields/Types/AsyncBelongsToField.php
@@ -115,9 +115,7 @@ class AsyncBelongsToField extends Field
      */
     public function getSelectedLabel(mixed $id): ?string
     {
-        if (!$id) {
-            return null;
-        }
+        if (!$id) return null;
 
         $modelClass = $this->getRelatedModel();
         $record = $modelClass::find($id);

--- a/src/Fields/Types/BelongsToField.php
+++ b/src/Fields/Types/BelongsToField.php
@@ -19,8 +19,6 @@ class BelongsToField extends Field
     public string $displayColumn = 'name';
     protected ?Model $parentModel = null;
     public bool $createInForm = false;
-    /** @var array<string, mixed>|null */
-    protected ?array $optionsCache = null;
 
     /**
      * BelongsToField constructor.
@@ -56,7 +54,6 @@ class BelongsToField extends Field
     public function relatedTo(string $model): self
     {
         $this->relatedModel = $model;
-        $this->optionsCache = null;
         return $this;
     }
 
@@ -69,7 +66,6 @@ class BelongsToField extends Field
     public function setParentModel(Model $parentModel): self
     {
         $this->parentModel = $parentModel;
-        $this->optionsCache = null;
         return $this;
     }
 
@@ -104,7 +100,6 @@ class BelongsToField extends Field
     {
         $this->returnColumn = $returnColumn;
         $this->displayColumn = $displayColumn;
-        $this->optionsCache = null;
         return $this;
     }
 
@@ -144,16 +139,11 @@ class BelongsToField extends Field
      */
     public function getOptions(): array
     {
-        if ($this->optionsCache !== null) {
-            return $this->optionsCache;
-        }
-
         $relatedModel = $this->getRelatedModel();
-        $table = (new $relatedModel())->getTable();
+        $table = (new $relatedModel)->getTable();
 
-        $this->optionsCache = $relatedModel::query()
+        return $relatedModel::query()
             ->pluck("{$table}.{$this->displayColumn}", "{$table}.{$this->returnColumn}")
             ->toArray();
-        return $this->optionsCache;
     }
 }

--- a/src/Fields/Types/BelongsToManyField.php
+++ b/src/Fields/Types/BelongsToManyField.php
@@ -135,7 +135,7 @@ class BelongsToManyField extends Field
     public function getOptions(): array
     {
         $relatedModel = $this->getRelatedModel();
-        $table = (new $relatedModel())->getTable();
+        $table = (new $relatedModel)->getTable();
 
         return $relatedModel::query()
             ->pluck("{$table}.{$this->displayColumn}", "{$table}.{$this->returnColumn}")

--- a/src/Fields/Types/DateTimeField.php
+++ b/src/Fields/Types/DateTimeField.php
@@ -34,11 +34,8 @@ class DateTimeField extends Field
      * @param string $type The internal field type.
      * @return self
      */
-    public static function make(
-        string $name = 'created_at',
-        ?string $label = 'Created At',
-        string $type = 'datetime'
-    ): self {
+    public static function make(string $name = 'created_at', ?string $label = 'Created At', string $type = 'datetime'): self
+    {
         return new self($name, $label, $type);
     }
 }

--- a/src/Fields/Types/SelectField.php
+++ b/src/Fields/Types/SelectField.php
@@ -18,9 +18,6 @@ class SelectField extends Field
 
     protected bool $nullable = false;
 
-    /** @var array<string, mixed>|null Cache for resolved options within a request */
-    protected ?array $resolvedOptions = null;
-
     /**
      * Create a new SelectField instance.
      *
@@ -47,7 +44,6 @@ class SelectField extends Field
     public function options(array|Closure|string $options): self
     {
         $this->options = $options;
-        $this->resolvedOptions = null;
 
         return $this;
     }
@@ -57,26 +53,19 @@ class SelectField extends Field
      */
     public function getOptions(): array
     {
-        if ($this->resolvedOptions !== null) {
-            return $this->resolvedOptions;
-        }
-
         if ($this->options instanceof Closure) {
-            $this->resolvedOptions = call_user_func($this->options);
-            return $this->resolvedOptions;
+            return call_user_func($this->options);
         }
 
         if (is_string($this->options) && enum_exists($this->options)) {
-            $this->resolvedOptions = collect(($this->options)::cases())
+            return collect(($this->options)::cases())
                 ->mapWithKeys(fn ($case) => [
                     $case->value => method_exists($case, 'label') ? $case->label() : $case->name,
                 ])
                 ->toArray();
-            return $this->resolvedOptions;
         }
 
-        $this->resolvedOptions = $this->options ?? [];
-        return $this->resolvedOptions;
+        return $this->options ?? [];
     }
 
     public function label(string $value): static

--- a/src/Fields/Types/TextField.php
+++ b/src/Fields/Types/TextField.php
@@ -13,24 +13,24 @@ class TextField extends Field
      * Create a new TextField instance.
      *
      * @param string $name The name of the field (default: 'name').
-     * @param string|null $label The display label (auto-generated if null).
+     * @param string|null $label The display label (default: 'Name').
      * @param string $type The field type (default: 'text').
      */
-    public function __construct(string $name = 'name', ?string $label = null, string $type = 'text')
+    public function __construct(string $name = 'name', ?string $label = 'Name', string $type = 'text')
     {
         parent::__construct($name, $label, $type);
-        $this->sortable();
+        $this->label($label)->sortable();
     }
 
     /**
      * Static factory method to create a new TextField.
      *
      * @param string $name The name of the field.
-     * @param string|null $label Optional label (auto-generated if null).
+     * @param string|null $label Optional label.
      * @param string $type The input type (default: 'text').
      * @return self
      */
-    public static function make(string $name, ?string $label = null, string $type = 'text'): self
+    public static function make(string $name = 'name', ?string $label = 'Name', string $type = 'text'): self
     {
         return new self($name, $label, $type);
     }

--- a/src/Http/Controllers/BuildoraController.php
+++ b/src/Http/Controllers/BuildoraController.php
@@ -99,11 +99,7 @@ class BuildoraController extends Controller
         $filteredData = array_intersect_key($finalData, array_flip($fields));
 
         if (empty($filteredData)) {
-            return redirect()->back()
-                ->with(
-                    'error',
-                    __buildora('No valid fields to save. Check fields in resource.', [':model' => $model])
-                );
+            return redirect()->back()->with('error', __buildora('No valid fields to save. Check fields in resource.', [':model' => $model]));
         }
 
         $createdItem = $modelInstance::create($filteredData);
@@ -197,7 +193,8 @@ class BuildoraController extends Controller
     public function show(string $model, int|string $id)
     {
         $resource = ResourceResolver::resolve($model);
-        $item = $resource::query()->findOrFail($id);
+        // Use queryWithRelations() for detail view to eager-load panel relations
+        $item = $resource::queryWithRelations()->findOrFail($id);
         $resource->fill($item);
 
         $customView = $resource->getDetailView();

--- a/src/Layouts/Panel.php
+++ b/src/Layouts/Panel.php
@@ -11,8 +11,7 @@ class Panel
         public string $relationName,
         public string $resourceClass,
         protected ?string $label = null,
-    ) {
-    }
+    ) {}
 
     /**
      * Koppel een relationele resource op basis van een relatienaam (zoals 'orders')

--- a/src/Providers/BuildoraServiceProvider.php
+++ b/src/Providers/BuildoraServiceProvider.php
@@ -74,7 +74,7 @@ class BuildoraServiceProvider extends ServiceProvider
             $view->with('buildoraBreadcrumbs', BuildoraBreadcrumbBuilder::generate());
         });
 
-        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
 
         $composerPath = dirname(__DIR__, 2) . '/composer.json';
 

--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -102,9 +102,7 @@ abstract class BuildoraResource
         foreach ($fields as $field) {
             if (! $field instanceof Field) {
                 $type = is_object($field) ? get_class($field) : gettype($field);
-                throw new BuildoraException(
-                    "Ongeldig veld in " . static::class . ": verwacht een Field-object, kreeg {$type}"
-                );
+                throw new BuildoraException("Ongeldig veld in " . static::class . ": verwacht een Field-object, kreeg {$type}");
             }
         }
 
@@ -183,9 +181,7 @@ abstract class BuildoraResource
         foreach ($fields as $field) {
             if (! $field instanceof \Ginkelsoft\Buildora\Fields\Field) {
                 $type = is_object($field) ? get_class($field) : gettype($field);
-                throw new BuildoraException(
-                    "Ongeldig veld in " . static::class . ": verwacht een Field-object, kreeg {$type}"
-                );
+                throw new BuildoraException("Ongeldig veld in " . static::class . ": verwacht een Field-object, kreeg {$type}");
             }
         }
 
@@ -224,13 +220,25 @@ abstract class BuildoraResource
     }
 
     /**
-     * Return the query builder for this resource.
+     * Return the query builder for this resource WITHOUT eager-loading relations.
+     * Use this for index/list views for optimal performance.
      *
      * @return \Ginkelsoft\Buildora\BuildoraQueryBuilder
      */
     public static function query(): \Ginkelsoft\Buildora\BuildoraQueryBuilder
     {
-        return QueryFactory::make(new static());
+        return QueryFactory::make(new static(), false);
+    }
+
+    /**
+     * Return the query builder for this resource WITH eager-loading of panel relations.
+     * Use this for detail/show views where relations are needed.
+     *
+     * @return \Ginkelsoft\Buildora\BuildoraQueryBuilder
+     */
+    public static function queryWithRelations(): \Ginkelsoft\Buildora\BuildoraQueryBuilder
+    {
+        return QueryFactory::make(new static(), true);
     }
 
     public function setDetailView(string $view): static
@@ -281,9 +289,8 @@ abstract class BuildoraResource
         return strtolower(str_replace('Buildora', '', class_basename(static::class)));
     }
 
-    public function loadWithRelations(
-        \Illuminate\Database\Eloquent\Builder $query
-    ): \Illuminate\Database\Eloquent\Builder {
+    public function loadWithRelations(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
+    {
         $relations = collect($this->getRelationResources())
             ->pluck('relationName')
             ->filter()

--- a/src/Resources/FieldManager.php
+++ b/src/Resources/FieldManager.php
@@ -26,12 +26,10 @@ class FieldManager
                 $field->setParentModel($model);
             }
 
-            $shouldHydrateValue = !($model instanceof Model) || $model->exists;
-
-            if ($shouldHydrateValue && method_exists($field, 'setValue')) {
+            if (method_exists($field, 'setValue')) {
                 $field->setValue($model);
             } else {
-                $field->value = $model instanceof Model ? ($model->{$field->name} ?? null) : null;
+                $field->value = $model->{$field->name} ?? null;
             }
 
             return $field;

--- a/src/Resources/ModelResolver.php
+++ b/src/Resources/ModelResolver.php
@@ -20,8 +20,7 @@ class ModelResolver
      */
     public static function resolve(string $resourceClass): string
     {
-        $modelClass = $resourceClass::$model
-            ?? "App\\Models\\" . str_replace('Buildora', '', class_basename($resourceClass));
+        $modelClass = $resourceClass::$model ?? "App\\Models\\" . str_replace('Buildora', '', class_basename($resourceClass));
 
         BuildoraValidator::assertValidModel($modelClass);
 

--- a/src/Resources/QueryFactory.php
+++ b/src/Resources/QueryFactory.php
@@ -7,8 +7,8 @@ use Ginkelsoft\Buildora\BuildoraQueryBuilder;
 /**
  * Class QueryFactory
  *
- * Factory to create a BuildoraQueryBuilder for a given resource,
- * automatically eager-loading defined panel relations.
+ * Factory to create a BuildoraQueryBuilder for a given resource.
+ * Can optionally eager-load defined panel relations for detail views.
  */
 class QueryFactory
 {
@@ -16,15 +16,16 @@ class QueryFactory
      * Create a new BuildoraQueryBuilder instance for the given resource.
      *
      * @param BuildoraResource $resource
+     * @param bool $eagerLoadRelations Whether to eager-load panel relations (default: false for performance)
      * @return BuildoraQueryBuilder
      */
-    public static function make(BuildoraResource $resource): BuildoraQueryBuilder
+    public static function make(BuildoraResource $resource, bool $eagerLoadRelations = false): BuildoraQueryBuilder
     {
         // Maak de basisquery voor het model van deze resource
         $query = $resource->getModelInstance()->newQuery();
 
-        // ✅ Automatisch eager loaden van relaties uit definePanels()
-        if (method_exists($resource, 'getRelationResources')) {
+        // ✅ Eager load relaties alleen wanneer expliciet gevraagd (bijv. detail view)
+        if ($eagerLoadRelations && method_exists($resource, 'getRelationResources')) {
             $relations = collect($resource->getRelationResources())
                 ->pluck('relationName')
                 ->filter()

--- a/src/Support/BuildoraBreadcrumbBuilder.php
+++ b/src/Support/BuildoraBreadcrumbBuilder.php
@@ -40,7 +40,7 @@ class BuildoraBreadcrumbBuilder
                 $class = 'App\\Buildora\\Resources\\' . ucfirst($resourceMeta['name']) . 'Buildora';
 
                 if (class_exists($class)) {
-                    $resource = new $class();
+                    $resource = new $class;
                     $label = method_exists($resource, 'title') ? $resource->title() : $resourceMeta['label'] ?? $label;
                 }
             }

--- a/src/Support/NavigationBuilder.php
+++ b/src/Support/NavigationBuilder.php
@@ -18,11 +18,7 @@ class NavigationBuilder
         $navigation = [];
 
         $dashboardsConfig = config('buildora.dashboards', []);
-        if (
-            ($dashboardsConfig['enabled'] ?? false)
-            && isset($dashboardsConfig['children'])
-            && is_array($dashboardsConfig['children'])
-        ) {
+        if (($dashboardsConfig['enabled'] ?? false) && isset($dashboardsConfig['children']) && is_array($dashboardsConfig['children'])) {
             $dashboardChildren = [];
 
             foreach ($dashboardsConfig['children'] as $key => $dashboard) {
@@ -30,11 +26,7 @@ class NavigationBuilder
                     continue;
                 }
 
-                if (
-                    isset($dashboard['permission'])
-                    && (!auth()->check()
-                        || !auth()->user()->can($dashboard['permission']))
-                ) {
+                if (isset($dashboard['permission']) && (!auth()->check() || !auth()->user()->can($dashboard['permission']))) {
                     continue;
                 }
 
@@ -124,7 +116,7 @@ class NavigationBuilder
                         $label = Str::title(str_replace('Buildora', '', $resource['resource']));
 
                         if (class_exists($class)) {
-                            $instance = new $class();
+                            $instance = new $class;
                             if (method_exists($instance, 'title')) {
                                 $label = $instance->title();
                             }

--- a/src/Traits/HasBuildora.php
+++ b/src/Traits/HasBuildora.php
@@ -19,7 +19,7 @@ trait HasBuildora
      */
     public static function getFields(): array
     {
-        $instance = new static();
+        $instance = new static;
 
         return [
             'fillable' => $instance->getFillable(),
@@ -35,7 +35,7 @@ trait HasBuildora
      */
     private static function getBuildoraRelations(): array
     {
-        $instance = new static();
+        $instance = new static;
         $relations = [];
 
         foreach (get_class_methods($instance) as $method) {

--- a/src/View/Components/Widgets.php
+++ b/src/View/Components/Widgets.php
@@ -7,6 +7,7 @@ use Illuminate\View\Component;
 
 class Widgets extends Component
 {
+
     /**
      * The Buildora resource instance.
      *


### PR DESCRIPTION
  Remove complex performance optimizations in favor of cleaner, more maintainable code:

  - Remove pagination_strategy config option (always use length_aware)
  - Simplify datatable JavaScript (remove duplicate request prevention)
  - Remove column selection optimization - back to SELECT *
  - Remove BelongsTo eager loading optimization
  - Remove join-based search optimization - back to whereHas
  - Remove specialized formatRecords and pagination meta methods
  - Restore standard Laravel pagination behavior

  The previous optimizations added significant complexity without clear evidence of performance
  benefit in production. This simpler implementation is easier to maintain and debug.