### PR TITLE
feat: add PageAction system with permission sync button

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,6 +1,7 @@
 @extends('buildora::layouts.buildora')
 
 @section('content')
+<div x-data="pageActionsHandler()">
 
     <x-buildora::widgets :resource="$resource" visibility="index" />
 
@@ -21,15 +22,194 @@
         {{ $resource->title() }}
     </h1>
 
-    @can(Str::kebab($model) . '.create')
-        <div class="flex justify-end mb-4">
+    <div class="flex justify-between items-center mb-4">
+        <!-- Page Actions (links) -->
+        @if(isset($pageActions) && count($pageActions) > 0)
+            <div class="flex gap-2">
+                @foreach($pageActions as $action)
+                    <button
+                        @click="executePageAction({{ json_encode($action->toArray()) }})"
+                        class="inline-flex items-center px-4 py-2
+                            @if($action->getStyle() === 'primary') bg-primary text-primary-foreground
+                            @elseif($action->getStyle() === 'secondary') bg-secondary text-secondary-foreground
+                            @elseif($action->getStyle() === 'success') bg-green-600 text-white
+                            @elseif($action->getStyle() === 'danger') bg-red-600 text-white
+                            @elseif($action->getStyle() === 'warning') bg-yellow-600 text-white
+                            @endif
+                            font-semibold rounded-lg shadow-md hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition duration-200 ease-in-out">
+                        <x-buildora-icon :icon="$action->getIcon()" class="mr-2" />
+                        {{ $action->getLabel() }}
+                    </button>
+                @endforeach
+            </div>
+        @else
+            <div></div>
+        @endif
+
+        <!-- Create Button (rechts) -->
+        @can(Str::kebab($model) . '.create')
             <a href="{{ route('buildora.create', ['resource' => $model]) }}"
                class="inline-flex items-center px-6 py-3 bg-primary text-primary-foreground font-semibold rounded-lg shadow-md hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 transition duration-200 ease-in-out">
                 <x-buildora-icon icon="fa fa-plus" class="mr-2" />
                 {{ __buildora('create') }} {{ $resource->title() }}
             </a>
-        </div>
-    @endcan
+        @endcan
+    </div>
 
     <x-buildora::datatable :columns="$columns"/>
+
+    <!-- Status Modal -->
+    <div x-show="showModal"
+         x-cloak
+         class="fixed inset-0 z-50 overflow-y-auto"
+         @keydown.escape.window="showModal = false">
+        <!-- Backdrop -->
+        <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+             @click="showModal = false"></div>
+
+        <!-- Modal Content -->
+        <div class="flex items-center justify-center min-h-screen p-4">
+            <div class="relative bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full p-6"
+                 @click.stop>
+                <!-- Header -->
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="text-xl font-semibold text-gray-900 dark:text-white">
+                        <span x-text="modalTitle"></span>
+                    </h3>
+                    <button @click="showModal = false"
+                            class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+                        <x-buildora-icon icon="fa fa-times" class="text-xl" />
+                    </button>
+                </div>
+
+                <!-- Status -->
+                <div class="mb-4">
+                    <!-- Loading -->
+                    <div x-show="isLoading" class="flex items-center gap-3 text-blue-600">
+                        <div class="animate-spin">
+                            <x-buildora-icon icon="fa fa-spinner" class="text-2xl" />
+                        </div>
+                        <span class="font-medium">Bezig met synchroniseren...</span>
+                    </div>
+
+                    <!-- Success -->
+                    <div x-show="!isLoading && modalSuccess"
+                         class="flex items-center gap-3 text-green-600 dark:text-green-400">
+                        <x-buildora-icon icon="fa fa-check-circle" class="text-2xl" />
+                        <span class="font-semibold" x-text="modalMessage"></span>
+                    </div>
+
+                    <!-- Error -->
+                    <div x-show="!isLoading && !modalSuccess && modalMessage"
+                         class="flex items-center gap-3 text-red-600 dark:text-red-400">
+                        <x-buildora-icon icon="fa fa-exclamation-circle" class="text-2xl" />
+                        <span class="font-semibold" x-text="modalMessage"></span>
+                    </div>
+                </div>
+
+                <!-- Details -->
+                <div x-show="modalDetails" class="mb-4 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+                    <div class="grid grid-cols-3 gap-4 text-center">
+                        <div>
+                            <div class="text-2xl font-bold text-green-600 dark:text-green-400"
+                                 x-text="modalDetails.registered || 0"></div>
+                            <div class="text-sm text-gray-600 dark:text-gray-400">Geregistreerd</div>
+                        </div>
+                        <div>
+                            <div class="text-2xl font-bold text-gray-600 dark:text-gray-400"
+                                 x-text="modalDetails.skipped || 0"></div>
+                            <div class="text-sm text-gray-600 dark:text-gray-400">Overgeslagen</div>
+                        </div>
+                        <div>
+                            <div class="text-2xl font-bold text-blue-600 dark:text-blue-400"
+                                 x-text="modalDetails.total || 0"></div>
+                            <div class="text-sm text-gray-600 dark:text-gray-400">Totaal</div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Output Log -->
+                <div x-show="modalOutput.length > 0" class="mb-4">
+                    <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Output:</h4>
+                    <div class="bg-gray-900 text-green-400 p-4 rounded-lg font-mono text-sm max-h-64 overflow-y-auto">
+                        <template x-for="(line, index) in modalOutput" :key="index">
+                            <div x-text="line" class="mb-1"></div>
+                        </template>
+                    </div>
+                </div>
+
+                <!-- Actions -->
+                <div class="flex justify-end gap-3">
+                    <button @click="showModal = false"
+                            class="px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition">
+                        Sluiten
+                    </button>
+                    <button x-show="!isLoading && modalSuccess"
+                            @click="window.location.reload()"
+                            class="px-4 py-2 bg-primary text-primary-foreground rounded-lg hover:opacity-90 transition">
+                        Vernieuwen
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function pageActionsHandler() {
+    return {
+        showModal: false,
+        isLoading: false,
+        modalTitle: '',
+        modalMessage: '',
+        modalSuccess: false,
+        modalOutput: [],
+        modalDetails: null,
+
+        executePageAction(action) {
+            // Confirmation if needed
+            if (action.confirmMessage && !confirm(action.confirmMessage)) {
+                return;
+            }
+
+            this.showModal = true;
+            this.isLoading = true;
+            this.modalTitle = action.label;
+            this.modalMessage = '';
+            this.modalSuccess = false;
+            this.modalOutput = [];
+            this.modalDetails = null;
+
+            // Build URL
+            const url = action.route.startsWith('http')
+                ? action.route
+                : '{{ config("buildora.route_prefix", "buildora") }}/' + action.route.replace('buildora.', '').replace(/\./g, '/');
+
+            // Execute action
+            fetch(url, {
+                method: action.method || 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                    'Accept': 'application/json',
+                },
+                body: action.method !== 'GET' ? JSON.stringify(action.parameters || {}) : null
+            })
+            .then(response => response.json())
+            .then(data => {
+                this.isLoading = false;
+                this.modalSuccess = data.success || false;
+                this.modalMessage = data.message || 'Actie uitgevoerd';
+                this.modalOutput = data.output || [];
+                this.modalDetails = data.details || null;
+            })
+            .catch(error => {
+                this.isLoading = false;
+                this.modalSuccess = false;
+                this.modalMessage = 'Er is een fout opgetreden: ' + error.message;
+            });
+        }
+    }
+}
+</script>
 @endsection

--- a/routes/buildora.php
+++ b/routes/buildora.php
@@ -8,6 +8,7 @@ use Ginkelsoft\Buildora\Http\Controllers\BuildoraExportController;
 use Ginkelsoft\Buildora\Http\Controllers\BuildoraController;
 use Ginkelsoft\Buildora\Http\Controllers\GlobalSearchController;
 use Ginkelsoft\Buildora\Http\Controllers\RelationDatatableController;
+use Ginkelsoft\Buildora\Http\Controllers\PermissionSyncController;
 
 Route::prefix(config('buildora.route_prefix', 'buildora'))
     ->middleware(config('buildora.middleware', ['web', 'buildora.auth', 'buildora.ensure-user-resource']))
@@ -35,6 +36,15 @@ Route::prefix(config('buildora.route_prefix', 'buildora'))
 
         Route::get('/global-search', GlobalSearchController::class)
             ->name('buildora.global.search');
+
+        /*
+        |--------------------------------------------------------------------------
+        | Permission Management
+        |--------------------------------------------------------------------------
+        */
+        Route::post('/permissions/sync', [PermissionSyncController::class, 'sync'])
+            ->name('buildora.permissions.sync')
+            ->middleware(['web', 'auth']);
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Actions/PageAction.php
+++ b/src/Actions/PageAction.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Actions;
+
+/**
+ * Class PageAction
+ *
+ * Represents a page-level action that can be triggered from a resource index page.
+ * Similar to BulkAction but for general page operations.
+ */
+class PageAction
+{
+    protected ?string $permission = null;
+    protected string $label;
+    protected string $icon;
+    protected string $route;
+    protected string $method;
+    protected array $parameters = [];
+    protected ?string $confirmMessage = null;
+    protected string $style = 'primary'; // primary, secondary, success, danger, warning
+
+    /**
+     * PageAction constructor.
+     *
+     * @param string $label The display label of the action
+     * @param string $icon The icon class (e.g., FontAwesome)
+     * @param string $route The Laravel route name to trigger
+     * @param array $parameters Optional route parameters
+     */
+    public function __construct(string $label, string $icon, string $route, array $parameters = [])
+    {
+        $this->label = $label;
+        $this->icon = $icon;
+        $this->route = $route;
+        $this->parameters = $parameters;
+        $this->method = 'POST';
+    }
+
+    /**
+     * Factory method to quickly create a new PageAction instance.
+     */
+    public static function make(string $label, string $icon, string $route, array $parameters = []): self
+    {
+        return new self($label, $icon, $route, $parameters);
+    }
+
+    /**
+     * Set the HTTP method for this action.
+     */
+    public function method(string $method): self
+    {
+        $this->method = strtoupper($method);
+        return $this;
+    }
+
+    /**
+     * Set a confirmation message.
+     */
+    public function confirm(string $message): self
+    {
+        $this->confirmMessage = $message;
+        return $this;
+    }
+
+    /**
+     * Set the required permission for this action.
+     */
+    public function permission(string $permission): self
+    {
+        $this->permission = $permission;
+        return $this;
+    }
+
+    /**
+     * Set the button style.
+     */
+    public function style(string $style): self
+    {
+        $this->style = $style;
+        return $this;
+    }
+
+    /**
+     * Get the label.
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Get the icon.
+     */
+    public function getIcon(): string
+    {
+        return $this->icon;
+    }
+
+    /**
+     * Get the route name.
+     */
+    public function getRoute(): string
+    {
+        return $this->route;
+    }
+
+    /**
+     * Get the HTTP method.
+     */
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * Get the parameters.
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * Get the confirmation message.
+     */
+    public function getConfirmMessage(): ?string
+    {
+        return $this->confirmMessage;
+    }
+
+    /**
+     * Get the required permission.
+     */
+    public function getPermission(): ?string
+    {
+        return $this->permission;
+    }
+
+    /**
+     * Get the button style.
+     */
+    public function getStyle(): string
+    {
+        return $this->style;
+    }
+
+    /**
+     * Convert to array for JSON serialization.
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'icon' => $this->icon,
+            'route' => $this->route,
+            'method' => $this->method,
+            'parameters' => $this->parameters,
+            'confirmMessage' => $this->confirmMessage,
+            'permission' => $this->permission,
+            'style' => $this->style,
+        ];
+    }
+}

--- a/src/Commands/MakePermissionResourceCommand.php
+++ b/src/Commands/MakePermissionResourceCommand.php
@@ -71,6 +71,7 @@ use Ginkelsoft\Buildora\Fields\Types\TextField;
 use Ginkelsoft\Buildora\Fields\Types\SelectField;
 use Ginkelsoft\Buildora\Resources\BuildoraResource;
 use Ginkelsoft\Buildora\Actions\RowAction;
+use Ginkelsoft\Buildora\Actions\PageAction;
 
 class PermissionBuildora extends BuildoraResource
 {
@@ -132,6 +133,19 @@ class PermissionBuildora extends BuildoraResource
     public function definePanels(): array
     {
         return [];
+    }
+
+    public function definePageActions(): array
+    {
+        return [
+            PageAction::make(
+                'Permissions Synchroniseren',
+                'fas fa-sync',
+                'buildora.permissions.sync'
+            )
+                ->style('success')
+                ->permission('permission.create'),
+        ];
     }
 }
 PHP;

--- a/src/Http/Controllers/BuildoraDataTableController.php
+++ b/src/Http/Controllers/BuildoraDataTableController.php
@@ -22,8 +22,9 @@ class BuildoraDataTableController extends Controller
         $datatable = new BuildoraDatatable($model);
         $columns = $datatable->getColumns();
         $resource = ResourceResolver::resolve($model);
+        $pageActions = $resource->getPageActions();
 
-        return view('buildora::index', compact('columns', 'model', 'resource'));
+        return view('buildora::index', compact('columns', 'model', 'resource', 'pageActions'));
     }
 
     /**

--- a/src/Http/Controllers/PermissionSyncController.php
+++ b/src/Http/Controllers/PermissionSyncController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class PermissionSyncController
+{
+    /**
+     * Sync permissions by running the buildora:sync-permissions command.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function sync(Request $request): JsonResponse
+    {
+        try {
+            // Create a buffered output to capture command output
+            $output = new BufferedOutput();
+
+            // Run the sync command
+            $exitCode = Artisan::call('buildora:sync-permissions', [], $output);
+
+            // Get the command output
+            $commandOutput = $output->fetch();
+
+            // Parse the output to get individual lines
+            $lines = array_filter(explode("\n", $commandOutput));
+
+            if ($exitCode === 0) {
+                return response()->json([
+                    'success' => true,
+                    'message' => 'Permissions gesynchroniseerd',
+                    'output' => $lines,
+                    'details' => $this->parseOutput($lines),
+                ]);
+            }
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Er is een fout opgetreden bij het synchroniseren van permissions',
+                'output' => $lines,
+            ], 500);
+        } catch (\Exception $e) {
+            Log::error('Permission sync failed: ' . $e->getMessage());
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Fout: ' . $e->getMessage(),
+                'output' => [],
+            ], 500);
+        }
+    }
+
+    /**
+     * Parse the command output to extract useful information.
+     *
+     * @param array $lines
+     * @return array
+     */
+    protected function parseOutput(array $lines): array
+    {
+        $registered = 0;
+        $skipped = 0;
+
+        foreach ($lines as $line) {
+            if (str_contains($line, '✓ Registered:')) {
+                $registered++;
+            } elseif (str_contains($line, '⊗ Already exists:')) {
+                $skipped++;
+            }
+        }
+
+        return [
+            'registered' => $registered,
+            'skipped' => $skipped,
+            'total' => $registered + $skipped,
+        ];
+    }
+}

--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -142,6 +142,37 @@ abstract class BuildoraResource
     }
 
     /**
+     * Define page-level actions for this resource (shown on index page).
+     *
+     * @return array
+     */
+    public function definePageActions(): array
+    {
+        return [];
+    }
+
+    /**
+     * Get the page actions, filtered by permissions.
+     *
+     * @return array
+     */
+    public function getPageActions(): array
+    {
+        $actions = $this->definePageActions();
+
+        return collect($actions)
+            ->filter(function ($action) {
+                $permission = $action->getPermission();
+                if ($permission && auth()->check()) {
+                    return auth()->user()->can($permission);
+                }
+                return true;
+            })
+            ->values()
+            ->toArray();
+    }
+
+    /**
      * Return the row actions for a specific resource instance.
      *
      * @param object $resource


### PR DESCRIPTION
Add a new PageAction system that allows resources to define page-level actions shown on the index page. Implement permission sync functionality with real-time status feedback in a modal.

Features:
- PageAction class for defining page-level actions
- Permission sync controller with buffered command output
- Real-time status modal with loading, success, and error states
- Detailed statistics (registered, skipped, total)
- Command output log display
- Auto-refresh option after success
- Permission-based access control for actions

Permission Resource Changes:
- Add sync button to Permission resource
- Shows detailed sync progress and results
- Displays number of registered and skipped permissions
- Full command output in terminal-style log

Technical Details:
- Add definePageActions() method to BuildoraResource
- Add getPageActions() with permission filtering
- Update index view with Alpine.js modal component
- Add /permissions/sync route
- Integrate with buildora:sync-permissions command