### PR TITLE
fix(security): normalise sort direction at the datatable edge (refs #119)

### DIFF
--- a/src/Datatable/DataFetcher.php
+++ b/src/Datatable/DataFetcher.php
@@ -3,6 +3,7 @@
 namespace Ginkelsoft\Buildora\Datatable;
 
 use Ginkelsoft\Buildora\Support\SchemaCache;
+use Ginkelsoft\Buildora\Support\SortDirection;
 use Illuminate\Contracts\Pagination\Paginator as PaginatorContract;
 use Ginkelsoft\Buildora\Fields\Field;
 use Ginkelsoft\Buildora\Fields\Types\BelongsToField;
@@ -58,6 +59,11 @@ class DataFetcher
         int $perPage = 25,
         int $page = 1
     ): PaginatorContract {
+        // Defence in depth: even though Eloquent's orderBy() rejects invalid
+        // directions, it does so by throwing — which surfaces as a 500. We
+        // normalise the user-supplied value to a safe asc/desc up front.
+        $sortDirection = SortDirection::normalize($sortDirection);
+
         $query = call_user_func([$this->resourceClass, 'query']);
 
         /** @var Model $modelInstance */

--- a/src/Support/SortDirection.php
+++ b/src/Support/SortDirection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Support;
+
+/**
+ * Normalises a sort-direction string coming from untrusted input
+ * (e.g. a query parameter) into a strict "asc"|"desc" value.
+ *
+ * Laravel's QueryBuilder::orderBy() already throws on invalid directions,
+ * but that surfaces as a 500 error to the user. Normalising at the edge
+ * keeps datatable requests robust against typos and crafted payloads
+ * without leaking exception details.
+ */
+final class SortDirection
+{
+    public const ASC = 'asc';
+    public const DESC = 'desc';
+
+    /**
+     * Return a safe direction string. Falls back to "asc" for anything
+     * that is not strictly "asc" or "desc" (case-insensitive).
+     */
+    public static function normalize(mixed $direction): string
+    {
+        if (! is_string($direction)) {
+            return self::ASC;
+        }
+
+        $lower = strtolower(trim($direction));
+
+        return $lower === self::DESC ? self::DESC : self::ASC;
+    }
+}

--- a/tests/Unit/Support/SortDirectionTest.php
+++ b/tests/Unit/Support/SortDirectionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Support;
+
+use Ginkelsoft\Buildora\Support\SortDirection;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class SortDirectionTest extends TestCase
+{
+    #[Test]
+    public function asc_is_normalised_to_asc(): void
+    {
+        $this->assertSame('asc', SortDirection::normalize('asc'));
+    }
+
+    #[Test]
+    public function desc_is_normalised_to_desc(): void
+    {
+        $this->assertSame('desc', SortDirection::normalize('desc'));
+    }
+
+    #[Test]
+    public function casing_is_ignored(): void
+    {
+        $this->assertSame('asc', SortDirection::normalize('ASC'));
+        $this->assertSame('desc', SortDirection::normalize('DESC'));
+        $this->assertSame('desc', SortDirection::normalize('Desc'));
+    }
+
+    #[Test]
+    public function surrounding_whitespace_is_trimmed(): void
+    {
+        $this->assertSame('asc', SortDirection::normalize('  asc  '));
+        $this->assertSame('desc', SortDirection::normalize("\tdesc\n"));
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function untrustedInputs(): array
+    {
+        return [
+            'empty string'         => [''],
+            'unknown word'         => ['foo'],
+            'sql injection'        => ['asc; DROP TABLE users;--'],
+            'numeric'              => ['123'],
+            'null'                 => [null],
+            'integer'              => [1],
+            'boolean true'         => [true],
+            'boolean false'        => [false],
+            'array'                => [['asc']],
+            'object'               => [new \stdClass()],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('untrustedInputs')]
+    public function untrusted_or_invalid_input_falls_back_to_asc(mixed $input): void
+    {
+        $this->assertSame('asc', SortDirection::normalize($input));
+    }
+}


### PR DESCRIPTION
## Audit conclusie

Volledige review van `src/Datatable/DataFetcher.php` op SQL-injection in sort/filter.

| Vector | Conclusie |
|---|---|
| Sort column (user input) | **Safe** — eerst gematched tegen `defineFields()`, daarna `in_array($col, $databaseColumns)` whitelist tegen schema |
| Sort direction (user input) | **Was 500-prone** — Laravel gooit `InvalidArgumentException` op invalid waarden. Geen SQLi, maar wel een ruwe 500 voor end-users. **Deze PR fixt dat.** |
| Search column | **Safe** — uit `Field::getSearchColumn()` (developer-defined), additioneel gewhitelist |
| Search value | **Safe** — parameterised via Eloquent `where()` |

## Wijziging

Nieuwe helper `Ginkelsoft\Buildora\Support\SortDirection`:

\`\`\`php
SortDirection::normalize($input)
\`\`\`

- Returnt strikt `'asc'` of `'desc'`
- Case-insensitive
- Whitespace getrimd
- Niet-string / onbekende waardes → `'asc'`

Aangeroepen aan het begin van `DataFetcher::fetch()` zodat alle code daarna een gevalideerde waarde gebruikt.

## Tests

`SortDirectionTest` — **14 tests, 17 asserties**:
- ✓ `'asc'` → `'asc'`
- ✓ `'desc'` → `'desc'`
- ✓ Casing irrelevant (`'ASC'`, `'Desc'`)
- ✓ Whitespace getrimd
- ✓ Fallback voor: empty string, unknown word, SQL fragment `'asc; DROP TABLE users;--'`, numeric, null, int, bool, array, object

## Verificatie

- [x] `composer test` — alle tests groen
- [x] Geen breaking change voor legitieme requests (`'asc'` / `'desc'` werken zoals voorheen)
- [x] `?sortDirection=foo` valt nu naar `'asc'` i.p.v. 500-error
- [x] SQL injection-poging `?sortDirection=asc;DROP%20...` valt naar `'asc'`

## Closes #119

Audit gedocumenteerd hierboven. Sort column whitelist was al correct, alleen direction had een ergonomisch + defense-in-depth gat. Geen kritieke kwetsbaarheid gevonden.