### PR TITLE
fix(security): restrict relation payload to declared fields (closes #120)

### DIFF
--- a/src/Http/Controllers/BuildoraController.php
+++ b/src/Http/Controllers/BuildoraController.php
@@ -106,7 +106,7 @@ class BuildoraController extends Controller
         }
 
         $createdItem = $modelInstance::create($filteredData);
-        $this->handleRelationships($createdItem, $request->all());
+        $this->handleRelationships($createdItem, $this->relationPayload($resource, $modelInstance, $request));
 
         return redirect()->route('buildora.index', ['resource' => $model])
             ->with('success', ucfirst($model) . ' ' . __buildora('created successfully.'));
@@ -187,10 +187,27 @@ class BuildoraController extends Controller
         $filteredData = array_intersect_key($finalData, array_flip($fields));
 
         $item->update($filteredData);
-        $this->handleRelationships($item, $request->all());
+        $this->handleRelationships($item, $this->relationPayload($resource, $modelInstance, $request));
 
         return redirect()->route('buildora.index', ['resource' => $model])
             ->with('success', ucfirst($model) . ' ' . __buildora('updated successfully.'));
+    }
+
+    /**
+     * Build the payload that handleRelationships() is allowed to process.
+     *
+     * Without this filter, $request->all() would let a caller inject any
+     * relation-method name that exists on the model — even ones the resource
+     * never declared — and pivot/sync them. Restricting the keys to the
+     * names defined in defineFields() closes that mass-assignment hole.
+     */
+    protected function relationPayload(object $resource, object $modelInstance, Request $request): array
+    {
+        $allowedKeys = collect($resource->resolveFields($modelInstance))
+            ->map(fn ($field) => $field->name)
+            ->toArray();
+
+        return $request->only($allowedKeys);
     }
 
     public function show(string $model, int|string $id)

--- a/tests/Unit/Http/Controllers/BuildoraControllerRelationFilteringTest.php
+++ b/tests/Unit/Http/Controllers/BuildoraControllerRelationFilteringTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Http\Controllers;
+
+use Ginkelsoft\Buildora\Fields\Types\TextField;
+use Ginkelsoft\Buildora\Http\Controllers\BuildoraController;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
+use stdClass;
+
+/**
+ * Regression coverage for the mass-assignment fix on the relations side.
+ *
+ * Before the fix, BuildoraController::store()/update() passed $request->all()
+ * straight into handleRelationships(). A caller could inject any relation-method
+ * name that existed on the model — `roles`, `permissions`, etc. — even if the
+ * resource never declared those fields, and have them sync()'d.
+ *
+ * The fix narrows the payload to keys defined in defineFields().
+ */
+class BuildoraControllerRelationFilteringTest extends TestCase
+{
+    #[Test]
+    public function relation_payload_only_contains_keys_declared_in_resolve_fields(): void
+    {
+        $controller = new BuildoraController();
+        $method = new ReflectionMethod($controller, 'relationPayload');
+        $method->setAccessible(true);
+
+        $resource = new class {
+            public function resolveFields(mixed $model): array
+            {
+                return [
+                    TextField::make('name'),
+                    TextField::make('email'),
+                ];
+            }
+        };
+
+        $model = new stdClass();
+
+        $request = Request::create('/x', 'POST', [
+            'name'     => 'Wietse',
+            'email'    => 'wietse@example.com',
+            'roles'    => [1, 2, 3], // hostile: not declared in defineFields()
+            'is_admin' => true,      // hostile: not declared in defineFields()
+        ]);
+
+        $payload = $method->invoke($controller, $resource, $model, $request);
+
+        $this->assertSame(['name', 'email'], array_keys($payload));
+        $this->assertArrayNotHasKey('roles', $payload);
+        $this->assertArrayNotHasKey('is_admin', $payload);
+    }
+
+    #[Test]
+    public function relation_payload_is_empty_when_resource_declares_no_fields(): void
+    {
+        $controller = new BuildoraController();
+        $method = new ReflectionMethod($controller, 'relationPayload');
+        $method->setAccessible(true);
+
+        $resource = new class {
+            public function resolveFields(mixed $model): array
+            {
+                return [];
+            }
+        };
+
+        $request = Request::create('/x', 'POST', [
+            'attempted_relation' => [99],
+        ]);
+
+        $payload = $method->invoke($controller, $resource, new stdClass(), $request);
+
+        $this->assertSame([], $payload);
+    }
+
+    #[Test]
+    public function relation_payload_keeps_declared_relation_keys(): void
+    {
+        $controller = new BuildoraController();
+        $method = new ReflectionMethod($controller, 'relationPayload');
+        $method->setAccessible(true);
+
+        // When a resource *does* declare a relation field, the key is allowed
+        // through — handleRelationships() will then decide whether to sync it.
+        $resource = new class {
+            public function resolveFields(mixed $model): array
+            {
+                return [
+                    TextField::make('name'),
+                    TextField::make('roles'),
+                ];
+            }
+        };
+
+        $request = Request::create('/x', 'POST', [
+            'name'  => 'Wietse',
+            'roles' => [1, 2],
+        ]);
+
+        $payload = $method->invoke($controller, $resource, new stdClass(), $request);
+
+        $this->assertSame(['name' => 'Wietse', 'roles' => [1, 2]], $payload);
+    }
+}


### PR DESCRIPTION
## Audit conclusie

Volledige review van `BuildoraController::store()` en `update()` op mass assignment.

### Scalar fields (kolomwaarden)

| Stap | Conclusie |
|---|---|
| `\$fields = ...defineFields()...->map(fn->name)` | Whitelist uit field definities ✓ |
| `\$validatedData = \$request->validate(\$rules)` | Laravel validate filter ✓ |
| `\$allowedRequestData = \$request->only(\$fields)` | Whitelist filter ✓ |
| `\$filteredData = array_intersect_key(\$finalData, array_flip(\$fields))` | Tweede whitelist ✓ |
| `Model::create(\$filteredData)` | Veilig — fillable check + dubbele whitelist |

**Geen kwetsbaarheid op scalar side.**

### Relations side — **kwetsbaar (was)**

```php
\$createdItem = \$modelInstance::create(\$filteredData);
\$this->handleRelationships(\$createdItem, \$request->all());  // ⚠️
```

`handleRelationships()` itereert over élke key in de payload en bij een matching public relation-method op het model: `sync()` / `associate()` / `saveMany()`.

**Exploit:**

1. Resource declareert `['name', 'email']` in `defineFields()`
2. Model heeft `roles()` many-to-many (niet in fields)
3. Attacker: `POST /buildora/user/3?name=x&email=y&roles[]=ADMIN_ROLE_ID`
4. `handleRelationships()` ziet de `roles` key, herkent het als relation, en doet `\$user->roles()->sync([ADMIN_ROLE_ID])` — escalatie zonder dat `roles` ooit in de form zat.

## Fix

Nieuwe `relationPayload()` helper die `\$request->only(\$declaredFieldNames)` returnt, waar `\$declaredFieldNames` uit `defineFields()` komt. `handleRelationships()` krijgt daarna alleen keys die de developer expliciet heeft gedeclareerd.

```php
\$createdItem = \$modelInstance::create(\$filteredData);
\$this->handleRelationships(\$createdItem, \$this->relationPayload(\$resource, \$modelInstance, \$request));
```

## Tests

`BuildoraControllerRelationFilteringTest` — 3 unit tests via reflection op de protected helper:

1. ✓ Hostile keys (`roles`, `is_admin`) worden gestript wanneer ze niet in `defineFields()` staan
2. ✓ Lege `defineFields()` → lege payload
3. ✓ Echte declared relation keys (`roles` wel in fields) blijven doorkomen

## Verificatie

- [x] `composer test` — alle tests groen
- [x] Backwards compat: legitieme requests met gedeclareerde fields werken zoals voorheen
- [x] Onverwachte keys uit request worden gefilterd vóór `handleRelationships()`

## Closes #120