### PR TITLE
fix(security): sanitise rich-text output to prevent stored XSS (closes #122)

### DIFF
--- a/resources/views/components/input/richtext.blade.php
+++ b/resources/views/components/input/richtext.blade.php
@@ -1,7 +1,7 @@
 <div class="relative">
     <div class="p-4 rounded-xl prose prose-sm max-w-none dark:prose-invert"
          style="background: var(--bg-input); border: 1px solid var(--border-color); color: var(--text-primary);">
-        {!! $value !!}
+        {!! \Ginkelsoft\Buildora\Support\HtmlSanitizer::clean($value ?? '') !!}
     </div>
 
     @include('buildora::components.field.help')

--- a/src/Support/HtmlSanitizer.php
+++ b/src/Support/HtmlSanitizer.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Support;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+
+/**
+ * Minimal allow-list-based HTML sanitiser for rich-text output.
+ *
+ * Buildora's RichTextField renders WYSIWYG content directly into the page,
+ * so any HTML stored against the model needs to be cleaned before it reaches
+ * the browser — otherwise a stored <script> tag (or an attribute payload
+ * like onerror="…" / href="javascript:…") becomes stored XSS.
+ *
+ * Implementation notes:
+ *   - Pure PHP, no external dependency (no HTMLPurifier).
+ *   - Strips any tag not in the whitelist; strips any attribute not in the
+ *     per-tag whitelist.
+ *   - Refuses href/src URLs that use a non-http(s)/mailto/tel scheme so that
+ *     `javascript:` and `data:` payloads cannot survive.
+ *   - Strips on* event-handler attributes unconditionally.
+ *
+ * Anything stricter (a full security boundary) should use a vetted library
+ * like HTMLPurifier — but this class closes the most common attack paths
+ * without adding a heavy dep.
+ */
+final class HtmlSanitizer
+{
+    /**
+     * @var array<string, array<int, string>>
+     *   Map of allowed tag => list of allowed attributes on that tag.
+     */
+    private const DEFAULT_WHITELIST = [
+        'p'          => [],
+        'br'         => [],
+        'strong'     => [],
+        'b'          => [],
+        'em'         => [],
+        'i'          => [],
+        'u'          => [],
+        's'          => [],
+        'sub'        => [],
+        'sup'        => [],
+        'h1'         => [],
+        'h2'         => [],
+        'h3'         => [],
+        'h4'         => [],
+        'h5'         => [],
+        'h6'         => [],
+        'ul'         => [],
+        'ol'         => [],
+        'li'         => [],
+        'blockquote' => [],
+        'pre'        => [],
+        'code'       => [],
+        'a'          => ['href', 'title', 'rel', 'target'],
+        'img'        => ['src', 'alt', 'title'],
+        'hr'         => [],
+        'span'       => [],
+        'div'        => [],
+        'figure'     => [],
+        'figcaption' => [],
+        'table'      => [],
+        'thead'      => [],
+        'tbody'      => [],
+        'tr'         => [],
+        'th'         => [],
+        'td'         => [],
+    ];
+
+    private const ALLOWED_URL_SCHEMES = ['http', 'https', 'mailto', 'tel'];
+
+    /**
+     * Clean an HTML string and return the sanitised result.
+     *
+     * @param array<string, array<int, string>>|null $whitelist Optional override of the tag/attribute whitelist.
+     */
+    public static function clean(?string $html, ?array $whitelist = null): string
+    {
+        if ($html === null || $html === '') {
+            return '';
+        }
+
+        $whitelist = $whitelist ?? self::DEFAULT_WHITELIST;
+
+        // Wrap in a fake root so DOMDocument doesn't add <html><body> wrappers
+        // and so that we can iterate over multiple top-level nodes.
+        $wrapped = '<?xml encoding="UTF-8"?><buildora-root>' . $html . '</buildora-root>';
+
+        $previous = libxml_use_internal_errors(true);
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadHTML($wrapped, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+
+        $root = $dom->getElementsByTagName('buildora-root')->item(0);
+        if ($root === null) {
+            return '';
+        }
+
+        self::sanitiseNode($root, $whitelist);
+
+        $output = '';
+        foreach ($root->childNodes as $child) {
+            $output .= $dom->saveHTML($child);
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param array<string, array<int, string>> $whitelist
+     */
+    private static function sanitiseNode(DOMNode $node, array $whitelist): void
+    {
+        // Walk children in reverse so removals don't shift the index.
+        $children = [];
+        foreach ($node->childNodes as $child) {
+            $children[] = $child;
+        }
+
+        foreach (array_reverse($children) as $child) {
+            if ($child instanceof DOMText) {
+                continue;
+            }
+
+            if (! $child instanceof DOMElement) {
+                $node->removeChild($child);
+                continue;
+            }
+
+            $tag = strtolower($child->nodeName);
+
+            if (! isset($whitelist[$tag])) {
+                self::unwrap($child);
+                continue;
+            }
+
+            self::stripDisallowedAttributes($child, $whitelist[$tag]);
+            self::sanitiseNode($child, $whitelist);
+        }
+    }
+
+    /**
+     * Replace a disallowed element with its (already-sanitised) children.
+     */
+    private static function unwrap(DOMElement $element): void
+    {
+        $parent = $element->parentNode;
+        if ($parent === null) {
+            return;
+        }
+
+        // For tags whose content we don't trust at all (script/style/iframe),
+        // drop the entire subtree.
+        $danger = ['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta'];
+        if (in_array(strtolower($element->nodeName), $danger, true)) {
+            $parent->removeChild($element);
+            return;
+        }
+
+        while ($element->firstChild !== null) {
+            $parent->insertBefore($element->firstChild, $element);
+        }
+        $parent->removeChild($element);
+    }
+
+    /**
+     * @param array<int, string> $allowedAttributes
+     */
+    private static function stripDisallowedAttributes(DOMElement $element, array $allowedAttributes): void
+    {
+        $remove = [];
+        foreach ($element->attributes as $attr) {
+            $name = strtolower($attr->nodeName);
+
+            // Always drop event handlers and any other on* attribute.
+            if (str_starts_with($name, 'on')) {
+                $remove[] = $attr->nodeName;
+                continue;
+            }
+
+            if (! in_array($name, $allowedAttributes, true)) {
+                $remove[] = $attr->nodeName;
+                continue;
+            }
+
+            if (in_array($name, ['href', 'src'], true) && ! self::isAllowedUrl((string) $attr->nodeValue)) {
+                $remove[] = $attr->nodeName;
+            }
+        }
+
+        foreach ($remove as $name) {
+            $element->removeAttribute($name);
+        }
+    }
+
+    private static function isAllowedUrl(string $value): bool
+    {
+        $value = trim($value);
+
+        if ($value === '') {
+            return false;
+        }
+
+        // Relative URLs (no scheme) are fine — same-origin.
+        if ($value[0] === '/' || $value[0] === '#' || $value[0] === '?') {
+            return true;
+        }
+
+        if (! preg_match('#^([a-z][a-z0-9+.\-]*):#i', $value, $match)) {
+            // No scheme — treat as relative.
+            return true;
+        }
+
+        return in_array(strtolower($match[1]), self::ALLOWED_URL_SCHEMES, true);
+    }
+}

--- a/tests/Unit/Support/HtmlSanitizerTest.php
+++ b/tests/Unit/Support/HtmlSanitizerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Support;
+
+use Ginkelsoft\Buildora\Support\HtmlSanitizer;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class HtmlSanitizerTest extends TestCase
+{
+    #[Test]
+    public function it_returns_empty_string_for_null_or_empty_input(): void
+    {
+        $this->assertSame('', HtmlSanitizer::clean(null));
+        $this->assertSame('', HtmlSanitizer::clean(''));
+    }
+
+    #[Test]
+    public function it_preserves_safe_formatting_tags(): void
+    {
+        $input = '<p>Hello <strong>world</strong> and <em>everyone</em>.</p>';
+
+        $output = HtmlSanitizer::clean($input);
+
+        $this->assertStringContainsString('<p>', $output);
+        $this->assertStringContainsString('<strong>', $output);
+        $this->assertStringContainsString('<em>', $output);
+        $this->assertStringContainsString('Hello', $output);
+    }
+
+    #[Test]
+    public function it_strips_script_tags_entirely(): void
+    {
+        $payload = '<p>Hi</p><script>alert("xss")</script>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('<script', $output);
+        $this->assertStringNotContainsString('alert', $output);
+        $this->assertStringContainsString('Hi', $output);
+    }
+
+    #[Test]
+    public function it_strips_iframe_object_embed_style_link_meta(): void
+    {
+        $payload = '<iframe src="x"></iframe><object></object><embed><style>body{}</style><link rel="x"><meta charset="utf-8">';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        foreach (['<iframe', '<object', '<embed', '<style', '<link', '<meta'] as $tag) {
+            $this->assertStringNotContainsString($tag, $output, "Did not expect to find {$tag} in output.");
+        }
+    }
+
+    #[Test]
+    public function it_strips_event_handler_attributes(): void
+    {
+        $payload = '<p onclick="alert(1)" onmouseover="boom()">Hi</p>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('onclick', $output);
+        $this->assertStringNotContainsString('onmouseover', $output);
+        $this->assertStringContainsString('Hi', $output);
+    }
+
+    #[Test]
+    public function it_strips_img_onerror_payload(): void
+    {
+        $payload = '<img src="x" onerror="alert(1)">';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('onerror', $output);
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function dangerousUrls(): array
+    {
+        return [
+            'javascript scheme' => ['javascript:alert(1)'],
+            'data url'          => ['data:text/html,<script>alert(1)</script>'],
+            'vbscript scheme'   => ['vbscript:msgbox("x")'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('dangerousUrls')]
+    public function it_drops_href_with_a_dangerous_url_scheme(string $url): void
+    {
+        $payload = '<a href="' . $url . '">click me</a>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('href=', $output);
+        $this->assertStringContainsString('click me', $output);
+    }
+
+    #[Test]
+    public function it_keeps_safe_http_https_mailto_tel_links(): void
+    {
+        $payload = implode('', [
+            '<a href="https://example.com">a</a>',
+            '<a href="http://example.com">b</a>',
+            '<a href="mailto:test@example.com">c</a>',
+            '<a href="tel:+31123">d</a>',
+            '<a href="/relative">e</a>',
+            '<a href="#anchor">f</a>',
+        ]);
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringContainsString('https://example.com', $output);
+        $this->assertStringContainsString('http://example.com', $output);
+        $this->assertStringContainsString('mailto:test@example.com', $output);
+        $this->assertStringContainsString('tel:+31123', $output);
+        $this->assertStringContainsString('/relative', $output);
+        $this->assertStringContainsString('#anchor', $output);
+    }
+
+    #[Test]
+    public function it_unwraps_unknown_tags_but_keeps_text_content(): void
+    {
+        $payload = '<custom-element>important text</custom-element>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('<custom-element', $output);
+        $this->assertStringContainsString('important text', $output);
+    }
+
+    #[Test]
+    public function it_strips_attributes_not_on_the_per_tag_whitelist(): void
+    {
+        // 'p' has no allowed attributes, so style/class/id should be stripped.
+        $payload = '<p class="bad" id="x" style="background:red">hi</p>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('class=', $output);
+        $this->assertStringNotContainsString('id=', $output);
+        $this->assertStringNotContainsString('style=', $output);
+        $this->assertStringContainsString('hi', $output);
+    }
+
+    #[Test]
+    public function it_allows_overriding_the_whitelist(): void
+    {
+        $payload = '<p>nope</p><strong>nope</strong><em>yes</em>';
+
+        $output = HtmlSanitizer::clean($payload, ['em' => []]);
+
+        $this->assertStringNotContainsString('<p', $output);
+        $this->assertStringNotContainsString('<strong', $output);
+        $this->assertStringContainsString('<em>yes</em>', $output);
+    }
+
+    #[Test]
+    public function nested_script_inside_safe_tag_is_stripped(): void
+    {
+        $payload = '<p>before <script>alert(1)</script> after</p>';
+
+        $output = HtmlSanitizer::clean($payload);
+
+        $this->assertStringNotContainsString('<script', $output);
+        $this->assertStringNotContainsString('alert', $output);
+        $this->assertStringContainsString('before', $output);
+        $this->assertStringContainsString('after', $output);
+    }
+}


### PR DESCRIPTION
## Audit conclusie — stored XSS bevestigd

`resources/views/components/input/richtext.blade.php` regel 4:

\`\`\`blade
{!! \$value !!}
\`\`\`

**Raw HTML rendering, geen sanitization.** Gecombineerd met `RichTextField`/`EditorField` (CKEditor input) is dit een stored-XSS sink: een gebruiker met edit-rechten kan `<script>alert(1)</script>` (of subtieler: `<img src=x onerror="…">`, `<a href="javascript:…">`) opslaan, en bij weergave wordt het uitgevoerd in de **admin context** van elke kijker.

## Oplossing

### `src/Support/HtmlSanitizer.php` (nieuw)

DOM-based sanitizer, **pure PHP, geen externe dependency** (geen HTMLPurifier).

**Allow-list strategy:**

| Element | Behandeling |
|---|---|
| Safe formatting tags (`p`, `strong`, `em`, `h1-6`, `ul/ol/li`, `blockquote`, `code`, `pre`, `a`, `img`, `table`-elements, …) | Behouden |
| Niet-whitelist tags (`<custom-element>`, etc.) | Unwrap — tag weg, tekst blijft |
| `<script>`, `<style>`, `<iframe>`, `<object>`, `<embed>`, `<link>`, `<meta>` | **Volledig gestript** (subtree weg) |
| `on*` event-handler attributes | **Altijd gestript** |
| Andere attributes niet op per-tag whitelist | Gestript (e.g. `class`/`style`/`id` op `<p>`) |
| `href`/`src` met `javascript:`, `data:`, `vbscript:` scheme | URL gedropt |
| `href`/`src` met `http`/`https`/`mailto`/`tel`/relatief | Behouden |

### `resources/views/components/input/richtext.blade.php` (gewijzigd)

\`\`\`blade
{!! \Ginkelsoft\Buildora\Support\HtmlSanitizer::clean(\$value ?? '') !!}
\`\`\`

Een-regel-wijziging. Elke RichTextField-display gaat nu door de sanitizer.

## Tests — 14 tests, 44 asserties

- ✓ Null/empty input → lege string
- ✓ Safe formatting (`<p>`, `<strong>`, `<em>`) behouden
- ✓ `<script>alert("xss")</script>` volledig gestript
- ✓ Alle 6 dangerous container tags gestript (iframe, object, embed, style, link, meta)
- ✓ `onclick`, `onmouseover`, `onerror` event handlers gestript
- ✓ `<a href="javascript:...">`, `data:`, `vbscript:` URL schemes gedropt
- ✓ Safe URLs (http/https/mailto/tel/relative/anchor) behouden
- ✓ Onbekende tags (`<custom-element>`) unwrapped, tekst behouden
- ✓ Per-tag attribute whitelist gehandhaafd (`<p class="bad">` → `<p>`)
- ✓ Custom whitelist override werkt
- ✓ Geneste `<script>` binnen safe tag wordt nog steeds gestript

## Verificatie

- [x] `composer test` — alle tests groen
- [x] Backwards compat: legitieme rich-text (Markdown-achtige output van CKEditor) blijft renderen
- [x] Geen externe dep toegevoegd

## Out of scope (vervolg)

- **Sanitize-on-save** (i.p.v. alleen sanitize-on-render): zou ook de DB cleanen, maar vereist een hook in `BuildoraController::store/update`. In een vervolg-PR — de huidige fix sluit de uitvoerings-vector.
- **HTMLPurifier integratie** als opt-in voor zwaardere use-cases.
- Audit op andere `{!! !!}` plekken in views (ViewField etc.). Aparte audit-issue indien gevonden.

## Closes #122