### PR TITLE
fix: HasOneField factory + ViewField label derivation (closes #142)

### DIFF
--- a/src/Fields/Types/HasOneField.php
+++ b/src/Fields/Types/HasOneField.php
@@ -37,6 +37,27 @@ class HasOneField extends Field
     }
 
     /**
+     * Static factory for HasOneField.
+     *
+     * Field::make() uses `new self()` (not `new static()`), so the inherited
+     * factory would otherwise return a base Field instance rather than a
+     * HasOneField. We override here to keep callers' chained type-specific
+     * methods (relatedTo, setParentModel) working.
+     *
+     * Signature mirrors the other field factories so callers don't need to
+     * special-case HasOneField; the $type argument is intentionally ignored
+     * (the constructor always sets 'hasOne').
+     *
+     * @param string $name
+     * @param string|null $label
+     * @param string $type Unused; kept for API consistency with other fields.
+     */
+    public static function make(string $name, ?string $label = null, string $type = 'hasOne'): self
+    {
+        return new self($name, $label);
+    }
+
+    /**
      * Set the related model class manually.
      *
      * @param string $model

--- a/src/Fields/Types/ViewField.php
+++ b/src/Fields/Types/ViewField.php
@@ -62,7 +62,7 @@ class ViewField extends Field
      * @param string $type
      * @return self
      */
-    public static function make(string $name = '', ?string $label = '', string $type = ''): self
+    public static function make(string $name = '', ?string $label = null, string $type = 'view'): self
     {
         return new self($name, $label, $type);
     }

--- a/tests/Unit/Fields/HasOneFieldTest.php
+++ b/tests/Unit/Fields/HasOneFieldTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Fields;
+
+use Ginkelsoft\Buildora\Fields\Field;
+use Ginkelsoft\Buildora\Fields\Types\HasOneField;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class HasOneFieldTest extends TestCase
+{
+    #[Test]
+    public function make_returns_a_hasone_field_instance(): void
+    {
+        $field = HasOneField::make('profile');
+
+        // Before #142 this asserted as Field but not HasOneField, because
+        // Field::make() uses `new self()` and HasOneField had no override.
+        $this->assertInstanceOf(Field::class, $field);
+        $this->assertInstanceOf(HasOneField::class, $field);
+    }
+
+    #[Test]
+    public function make_keeps_relation_type_label(): void
+    {
+        $field = HasOneField::make('profile');
+
+        $this->assertSame('profile', $field->name);
+        $this->assertSame('hasOne', $field->type);
+        $this->assertSame('Profile', $field->label);
+    }
+
+    #[Test]
+    public function make_accepts_an_explicit_label(): void
+    {
+        $field = HasOneField::make('profile', 'User Profile');
+
+        $this->assertSame('User Profile', $field->label);
+    }
+
+    #[Test]
+    public function relatedTo_returns_a_hasone_field_so_chains_keep_working(): void
+    {
+        $field = HasOneField::make('profile')->relatedTo(\stdClass::class);
+
+        // Builder chain must keep working — i.e. the type-specific method
+        // relatedTo returns an instance of HasOneField, not a base Field.
+        $this->assertInstanceOf(HasOneField::class, $field);
+    }
+}

--- a/tests/Unit/Fields/ViewFieldTest.php
+++ b/tests/Unit/Fields/ViewFieldTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Fields;
+
+use Ginkelsoft\Buildora\Fields\Types\ViewField;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+class ViewFieldTest extends TestCase
+{
+    #[Test]
+    public function make_derives_a_label_from_the_field_name(): void
+    {
+        // Before #142, ViewField::make() defaulted $label to '' (empty
+        // string, not null), which short-circuited the constructor's
+        // `$label ?? ucfirst($name)` fallback and left the label empty.
+        $field = ViewField::make('first_name');
+
+        $this->assertNotNull($field->label);
+        $this->assertNotSame('', $field->label);
+        $this->assertSame('First_name', $field->label);
+    }
+
+    #[Test]
+    public function make_accepts_an_explicit_label(): void
+    {
+        $field = ViewField::make('first_name', 'Voornaam');
+
+        $this->assertSame('Voornaam', $field->label);
+    }
+
+    #[Test]
+    public function make_uses_view_as_default_type(): void
+    {
+        $field = ViewField::make('first_name');
+
+        $this->assertSame('view', $field->type);
+    }
+}


### PR DESCRIPTION
## Bugs blootgelegd door FieldContractTest in PR #144

### 1. `HasOneField::make()` returnde een base `Field`

`Field::make()` gebruikt \`new self()\` (geen late static binding). Field types zonder eigen \`make()\` override krijgen een base \`Field\`-instance retour. \`HasOneField\` was de enige relation field zonder override.

**Fix:** voeg `make()` toe aan HasOneField, in lijn met `CheckboxListField` en `RelationLinkField`. Het derde `$type` argument wordt geaccepteerd voor API-consistentie maar genegeerd — de constructor zet zelf `'hasOne'`.

Switching `Field::make()` naar `new static()` was tempting maar zou de drie 2-parameter-constructor field types breken (HasOneField, CheckboxListField, RelationLinkField) — die zouden een "too many arguments" error krijgen.

### 2. `ViewField::make()` produceerde lege labels

\`\`\`php
public static function make(string \$name = '', ?string \$label = '', string \$type = ''): self
\`\`\`

Default `$label = ''` (lege string, niet null) — de `$label ?? ucfirst($name)` fallback in de constructor triggert alleen bij `null`. Bij `''` blijft het label leeg. Bonus: default `$type = ''` was ook fout.

**Fix:** default `$label = null`, default `$type = 'view'`.

## Tests

### `HasOneFieldTest` (4 tests)
- ✓ `make('profile')` returnt een `HasOneField` (niet langer `Field`)
- ✓ Type = `'hasOne'`, label derivation werkt
- ✓ Explicite label override
- ✓ Builder chain `relatedTo()` returnt nog steeds `HasOneField`

### `ViewFieldTest` (3 tests)
- ✓ `make('first_name')` heeft niet-leeg label
- ✓ Explicite label override
- ✓ Default type = `'view'`

## Follow-up

De 3 `markTestSkipped()` calls in PR #144's `FieldContractTest` kunnen weg zodra **beide PRs gemerged** zijn. Laat ik die hier expres staan — anders zou ik conflicts veroorzaken op `tests/Unit/Fields/FieldContractTest.php`.

## Closes #142