### PR TITLE
refactor: introduce BuildoraAbility enum for permission verbs (closes #139)

### DIFF
--- a/src/Authorization/BuildoraAbility.php
+++ b/src/Authorization/BuildoraAbility.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Authorization;
+
+/**
+ * Buildora-managed permission verbs.
+ *
+ * The four verbs map directly to the policy methods (viewAny/view, create,
+ * update, delete) and to the permission strings stored in Spatie. They were
+ * sprinkled as string literals throughout the codebase (policies, commands,
+ * middleware, controllers); centralising them here gives IDE autocomplete,
+ * a single point of typo-protection, and a typesafe `permissionString()`
+ * helper.
+ *
+ * Values are intentionally identical to the strings that were already in
+ * use, so existing permission rows in the database remain valid without
+ * a migration.
+ */
+enum BuildoraAbility: string
+{
+    case View = 'view';
+    case Create = 'create';
+    case Edit = 'edit';
+    case Delete = 'delete';
+
+    /**
+     * Compose the dotted permission identifier for a resource, matching the
+     * format Spatie expects (e.g. "user.view").
+     */
+    public function permissionString(string $resource): string
+    {
+        return "{$resource}.{$this->value}";
+    }
+
+    /**
+     * The default verb set generated for every resource.
+     *
+     * @return array<int, self>
+     */
+    public static function defaults(): array
+    {
+        return [self::View, self::Create, self::Edit, self::Delete];
+    }
+}

--- a/src/Commands/BuildoraSyncPermissionsCommand.php
+++ b/src/Commands/BuildoraSyncPermissionsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ginkelsoft\Buildora\Commands;
 
+use Ginkelsoft\Buildora\Authorization\BuildoraAbility;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Spatie\Permission\Models\Permission;
@@ -55,8 +56,9 @@ class BuildoraSyncPermissionsCommand extends Command
                 $modelName = str(class_basename($modelClass))->lower();
             }
 
-            foreach (['view', 'create', 'edit', 'delete'] as $action) {
-                $permissionName = "$modelName.$action";
+            foreach (BuildoraAbility::defaults() as $ability) {
+                $action = $ability->value;
+                $permissionName = $ability->permissionString($modelName);
                 $permission = Permission::findOrCreate($permissionName);
 
                 if ($hasLabelColumn && empty($permission->label)) {

--- a/src/Commands/GeneratePermissionsCommand.php
+++ b/src/Commands/GeneratePermissionsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ginkelsoft\Buildora\Commands;
 
+use Ginkelsoft\Buildora\Authorization\BuildoraAbility;
 use Illuminate\Console\Command;
 use Ginkelsoft\Buildora\Resources\BuildoraResource;
 use Spatie\Permission\Models\Permission;
@@ -42,9 +43,10 @@ class GeneratePermissionsCommand extends Command
             $resource = new $resourceClass();
             $resourceName = $resource->uriKey();
 
-            foreach (['view', 'create', 'edit', 'delete'] as $action) {
-                Permission::findOrCreate("{$resourceName}.{$action}");
-                $this->info("Created permission: {$resourceName}.{$action}");
+            foreach (BuildoraAbility::defaults() as $ability) {
+                $permission = $ability->permissionString($resourceName);
+                Permission::findOrCreate($permission);
+                $this->info("Created permission: {$permission}");
             }
         }
 

--- a/src/Policies/BuildoraPolicy.php
+++ b/src/Policies/BuildoraPolicy.php
@@ -3,8 +3,8 @@
 namespace Ginkelsoft\Buildora\Policies;
 
 use App\Models\User;
+use Ginkelsoft\Buildora\Authorization\BuildoraAbility;
 use Illuminate\Auth\Access\HandlesAuthorization;
-use Spatie\Permission\Models\Permission;
 
 abstract class BuildoraPolicy
 {
@@ -12,35 +12,33 @@ abstract class BuildoraPolicy
 
     abstract protected function resourceName(): string;
 
-    protected function hasPermission(User $user, string $action): bool
+    protected function hasPermission(User $user, BuildoraAbility $ability): bool
     {
-        $permission = "{$this->resourceName()}.{$action}";
-
-        return $user->hasPermissionTo($permission);
+        return $user->hasPermissionTo($ability->permissionString($this->resourceName()));
     }
 
     public function viewAny(User $user): bool
     {
-        return $this->hasPermission($user, 'view');
+        return $this->hasPermission($user, BuildoraAbility::View);
     }
 
     public function view(User $user, $model): bool
     {
-        return $this->hasPermission($user, 'view');
+        return $this->hasPermission($user, BuildoraAbility::View);
     }
 
     public function create(User $user): bool
     {
-        return $this->hasPermission($user, 'create');
+        return $this->hasPermission($user, BuildoraAbility::Create);
     }
 
     public function update(User $user, $model): bool
     {
-        return $this->hasPermission($user, 'edit');
+        return $this->hasPermission($user, BuildoraAbility::Edit);
     }
 
     public function delete(User $user, $model): bool
     {
-        return $this->hasPermission($user, 'delete');
+        return $this->hasPermission($user, BuildoraAbility::Delete);
     }
 }

--- a/tests/Unit/Authorization/BuildoraAbilityTest.php
+++ b/tests/Unit/Authorization/BuildoraAbilityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Authorization;
+
+use Ginkelsoft\Buildora\Authorization\BuildoraAbility;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class BuildoraAbilityTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: BuildoraAbility, 1: string}>
+     */
+    public static function abilityValues(): array
+    {
+        return [
+            'view'   => [BuildoraAbility::View,   'view'],
+            'create' => [BuildoraAbility::Create, 'create'],
+            'edit'   => [BuildoraAbility::Edit,   'edit'],
+            'delete' => [BuildoraAbility::Delete, 'delete'],
+        ];
+    }
+
+    /**
+     * Values must stay exactly equal to the legacy string literals — if any
+     * of these change, every existing row in the permissions table needs a
+     * migration.
+     */
+    #[Test]
+    #[DataProvider('abilityValues')]
+    public function each_case_keeps_its_legacy_string_value(BuildoraAbility $ability, string $expected): void
+    {
+        $this->assertSame($expected, $ability->value);
+    }
+
+    #[Test]
+    public function permission_string_composes_resource_and_value_with_a_dot(): void
+    {
+        $this->assertSame('user.view',     BuildoraAbility::View->permissionString('user'));
+        $this->assertSame('post.create',   BuildoraAbility::Create->permissionString('post'));
+        $this->assertSame('order.edit',    BuildoraAbility::Edit->permissionString('order'));
+        $this->assertSame('invoice.delete', BuildoraAbility::Delete->permissionString('invoice'));
+    }
+
+    #[Test]
+    public function defaults_returns_the_full_crud_quartet_in_a_stable_order(): void
+    {
+        // Order matters: GeneratePermissionsCommand prints them in this order
+        // and tests/integrations may rely on it.
+        $this->assertSame(
+            [
+                BuildoraAbility::View,
+                BuildoraAbility::Create,
+                BuildoraAbility::Edit,
+                BuildoraAbility::Delete,
+            ],
+            BuildoraAbility::defaults()
+        );
+    }
+
+    #[Test]
+    public function cases_count_is_locked(): void
+    {
+        // Adding a new ability is a deliberate change — make sure new
+        // abilities are also wired into defaults() and any consuming code.
+        $this->assertCount(4, BuildoraAbility::cases());
+    }
+}


### PR DESCRIPTION
## Probleem

Permission-verbs (\`'view'\`, \`'create'\`, \`'edit'\`, \`'delete'\`) zaten als bare strings verspreid over de codebase — \`BuildoraPolicy\`, \`GeneratePermissionsCommand\`, \`BuildoraSyncPermissionsCommand\`. Een typo in één plek (\`'updaet'\`) breekt permission enforcement **stil** — geen compile-time check, geen IDE-completion.

## Oplossing

### `src/Authorization/BuildoraAbility.php` (nieuw)

\`\`\`php
enum BuildoraAbility: string
{
    case View   = 'view';
    case Create = 'create';
    case Edit   = 'edit';
    case Delete = 'delete';

    public function permissionString(string \$resource): string
    {
        return \"{\$resource}.{\$this->value}\";
    }

    public static function defaults(): array
    {
        return [self::View, self::Create, self::Edit, self::Delete];
    }
}
\`\`\`

Enum-values zijn **identiek** aan de bestaande strings — geen DB-migratie nodig voor existing Spatie permission rows.

### Migrated callers

- **`BuildoraPolicy`** — `hasPermission()` accepteert nu een `BuildoraAbility` (typed). Alle policy methods refereren enum cases.
- **`GeneratePermissionsCommand`** — `foreach (BuildoraAbility::defaults() as \$ability)`.
- **`BuildoraSyncPermissionsCommand`** — idem.

## Tests — 7 tests

- ✓ Elke case heeft de juiste legacy-string value (regression guard tegen rename)
- ✓ `permissionString('user')` → `'user.view'`
- ✓ `defaults()` returns 4 abilities in stabiele volgorde
- ✓ Aantal cases gelocked op 4 — toevoegen vereist explicit code-change in defaults()

## Niet aangeraakt

- Spatie permission tables — values blijven hetzelfde
- Middleware (`CheckBuildoraPermission`) — die accepteert de action als route-param, niet als ability. Buiten scope.

## Closes #139