### PR TITLE
docs: clarify RichTextField (display) vs EditorField (input) roles (closes #137)

### DIFF
--- a/src/Fields/Types/EditorField.php
+++ b/src/Fields/Types/EditorField.php
@@ -5,7 +5,16 @@ namespace Ginkelsoft\Buildora\Fields\Types;
 use Ginkelsoft\Buildora\Fields\Field;
 
 /**
- * Represents a WYSIWYG HTML editor field using a rich editor like CKEditor.
+ * Form input for WYSIWYG-authored HTML content.
+ *
+ * Pairs with RichTextField (the read-only display side). Use EditorField on
+ * create/edit forms — the editor blade component renders a textarea wired
+ * up to CKEditor. Use RichTextField wherever the saved HTML is displayed
+ * back to the user.
+ *
+ * Captured input is stored verbatim. Sanitisation happens on the display
+ * path via RichTextField's blade component (#122), not here, so any custom
+ * read-only rendering of editor output must also call HtmlSanitizer::clean.
  */
 class EditorField extends Field
 {

--- a/src/Fields/Types/RichTextField.php
+++ b/src/Fields/Types/RichTextField.php
@@ -5,7 +5,16 @@ namespace Ginkelsoft\Buildora\Fields\Types;
 use Ginkelsoft\Buildora\Fields\Field;
 
 /**
- * Represents a field for rendering rich text (HTML) content in views only.
+ * Read-only display field for HTML content stored against a model.
+ *
+ * Pairs with EditorField (the input-side WYSIWYG textarea). Use RichTextField
+ * on detail/show views to render WYSIWYG-authored HTML; use EditorField on
+ * create/edit forms to capture it.
+ *
+ * Output is routed through HtmlSanitizer in the richtext blade component,
+ * which strips script/iframe/event handlers and rejects unsafe URL schemes —
+ * see #122. The sanitiser is the security boundary; don't bypass it by
+ * rendering field->value directly with {!! !!} in custom views.
  */
 class RichTextField extends Field
 {


### PR DESCRIPTION
## Audit conclusie

Bij inspectie blijken `RichTextField` en `EditorField` **geen duplicaten** — ze zijn complementaire halften van dezelfde workflow:

| Field | Rol | Blade view | Wanneer |
|---|---|---|---|
| `EditorField` | **input** | `editor.blade.php` (textarea + CKEditor) | Create/edit forms |
| `RichTextField` | **read-only display** | `richtext.blade.php` (HtmlSanitizer + `{!! !!}`) | Detail/show views |

De originele speculatie in mijn analyse ("duplicaat — beide renderen een editor") klopte niet bij betere code-inspectie. De classes verschillen slechts in `type`-string, en die string selecteert de juiste view (input vs display).

## Wijziging

Alleen **docblock updates** op beide classes. Geen gedragsverandering. Wat de nieuwe docs vertellen:

1. Welke is voor input, welke voor display
2. Cross-reference naar elkaar
3. De security boundary (HtmlSanitizer, #122) zit op de **display kant** — custom rendering van editor-output moet daar ook doorheen

## Effect

Consumers krijgen nu meteen uit de IDE / autocomplete tooltip te zien welke field ze moeten kiezen voor welke context. Geen consolidation, geen deprecation — alle bestaande code blijft werken.

## Closes #137