### PR TITLE
docs: clarify DisplayField vs ViewField roles (closes #138)

### DIFF
--- a/src/Fields/Types/DisplayField.php
+++ b/src/Fields/Types/DisplayField.php
@@ -6,7 +6,21 @@ use Closure;
 use Ginkelsoft\Buildora\Fields\Field;
 
 /**
- * A non-editable display-only field for rendering raw output or computed content.
+ * Read-only field that surfaces a computed string value.
+ *
+ * Use when you need to show a derived value next to the editable fields —
+ * a running total, a formatted timestamp, a status label. The content
+ * accepts either a plain string or a Closure that receives the current
+ * model and returns a string.
+ *
+ *   DisplayField::make('total')
+ *       ->content(fn (\$order) => '€ ' . number_format(\$order->total, 2));
+ *
+ * Sibling field types:
+ *   - ViewField — when you need a full Blade partial (HTML, charts, etc.)
+ *     rather than a single computed string.
+ *   - RichTextField — for read-only display of WYSIWYG-authored HTML
+ *     (routes through HtmlSanitizer).
  */
 class DisplayField extends Field
 {

--- a/src/Fields/Types/ViewField.php
+++ b/src/Fields/Types/ViewField.php
@@ -7,7 +7,23 @@ use Illuminate\Database\Eloquent\Model;
 use Closure;
 
 /**
- * Represents a custom field that renders a Blade view with optional dynamic data.
+ * Read-only field that renders a Blade partial.
+ *
+ * Use when a derived value isn't expressible as a single string — charts,
+ * tables, badge layouts, embedded components — and you'd rather hand the
+ * markup to a dedicated Blade view than build it in PHP.
+ *
+ *   ViewField::make('chart')
+ *       ->view('admin.partials.revenue-chart');
+ *
+ * Sibling field types:
+ *   - DisplayField — for simple computed strings; preferable when a Blade
+ *     partial would be overkill.
+ *   - RichTextField — for read-only display of user-stored HTML, with
+ *     automatic sanitisation.
+ *
+ * Performance note: a Blade view is rendered for *every datatable row*
+ * that includes this field. Prefer DisplayField in high-row contexts.
  */
 class ViewField extends Field
 {


### PR DESCRIPTION
## Audit conclusie

`DisplayField` en `ViewField` zijn **geen duplicaten** — twee escape hatches voor non-editable output met verschillende kosten:

| Field | Output | Cost | Wanneer |
|---|---|---|---|
| `DisplayField` | Computed string (Closure of literal) | Goedkoop | Running total, formatted date, status badge text |
| `ViewField` | Volledige Blade partial | Duur (factory-overhead per rij) | Chart, complex layout, embedded component |

## Wijziging

Docblock updates op beide classes. Geen gedragsverandering.

Wat de nieuwe docs vertellen:

1. **Intent in één zin** wat de field doet
2. **Voorbeeld** zodat de gebruiker meteen weet hoe te gebruiken
3. **Cross-reference** naar sibling fields (DisplayField ↔ ViewField, plus verwijzing naar RichTextField voor user-stored HTML)
4. **Performance hint** op ViewField: bij datatable-gebruik zal Blade per rij renderen — DisplayField is goedkoper voor simpele waarden

## Closes #138