### PR TITLE
perf: explicit QueryFactory::forList/forDetail entry points (closes #129)

### DIFF
--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -274,7 +274,7 @@ abstract class BuildoraResource
      */
     public static function query(): \Ginkelsoft\Buildora\BuildoraQueryBuilder
     {
-        return QueryFactory::make(new static(), false);
+        return QueryFactory::forList(new static());
     }
 
     /**
@@ -285,7 +285,7 @@ abstract class BuildoraResource
      */
     public static function queryWithRelations(): \Ginkelsoft\Buildora\BuildoraQueryBuilder
     {
-        return QueryFactory::make(new static(), true);
+        return QueryFactory::forDetail(new static());
     }
 
     public function setDetailView(string $view): static

--- a/src/Resources/QueryFactory.php
+++ b/src/Resources/QueryFactory.php
@@ -7,24 +7,51 @@ use Ginkelsoft\Buildora\BuildoraQueryBuilder;
 /**
  * Class QueryFactory
  *
- * Factory to create a BuildoraQueryBuilder for a given resource.
- * Can optionally eager-load defined panel relations for detail views.
+ * Builds a BuildoraQueryBuilder for a given resource, in one of two modes:
+ *
+ *  - forList()   — minimal: no panel relations eager-loaded. Used by the
+ *                  datatable, exports and any other listing context where
+ *                  the panels are never rendered. Without this distinction,
+ *                  every datatable row would drag a tree of unused
+ *                  relation rows behind it.
+ *
+ *  - forDetail() — full: eager-loads every relation declared via
+ *                  getRelationResources() (the panels Buildora will render
+ *                  on the detail page), so the page builds without N+1.
  */
 class QueryFactory
 {
     /**
-     * Create a new BuildoraQueryBuilder instance for the given resource.
+     * Build a query for listing contexts (datatable, exports, picklists).
+     * Panel relations are NOT eager-loaded.
+     */
+    public static function forList(BuildoraResource $resource): BuildoraQueryBuilder
+    {
+        return self::make($resource, false);
+    }
+
+    /**
+     * Build a query for the detail/show view. Panel relations declared by
+     * getRelationResources() are eager-loaded in a single batch.
+     */
+    public static function forDetail(BuildoraResource $resource): BuildoraQueryBuilder
+    {
+        return self::make($resource, true);
+    }
+
+    /**
+     * Generic constructor. Prefer forList() or forDetail() at call sites —
+     * they document the intent and avoid the boolean trap of a flag named
+     * "$eagerLoadRelations" passed without a label.
      *
      * @param BuildoraResource $resource
-     * @param bool $eagerLoadRelations Whether to eager-load panel relations (default: false for performance)
+     * @param bool $eagerLoadRelations Whether to eager-load panel relations.
      * @return BuildoraQueryBuilder
      */
     public static function make(BuildoraResource $resource, bool $eagerLoadRelations = false): BuildoraQueryBuilder
     {
-        // Maak de basisquery voor het model van deze resource
         $query = $resource->getModelInstance()->newQuery();
 
-        // ✅ Eager load relaties alleen wanneer expliciet gevraagd (bijv. detail view)
         if ($eagerLoadRelations && method_exists($resource, 'getRelationResources')) {
             $relations = collect($resource->getRelationResources())
                 ->pluck('relationName')
@@ -33,7 +60,7 @@ class QueryFactory
                 ->values()
                 ->toArray();
 
-            if (!empty($relations)) {
+            if (! empty($relations)) {
                 $query->with($relations);
             }
         }

--- a/tests/Unit/Resources/QueryFactoryTest.php
+++ b/tests/Unit/Resources/QueryFactoryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Resources;
+
+use Ginkelsoft\Buildora\Resources\BuildoraResource;
+use Ginkelsoft\Buildora\Resources\QueryFactory;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use Ginkelsoft\Buildora\Traits\HasBuildora;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+
+class QFArticle extends Model
+{
+    use HasBuildora;
+
+    protected $table = 'qf_articles';
+    protected $guarded = [];
+    public $timestamps = false;
+
+    public function tags()
+    {
+        return $this->hasMany(QFTag::class, 'article_id');
+    }
+}
+
+class QFTag extends Model
+{
+    use HasBuildora;
+
+    protected $table = 'qf_tags';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+class QFResourceWithPanels extends BuildoraResource
+{
+    public static function modelClass(): string
+    {
+        return QFArticle::class;
+    }
+
+    public function defineFields(): array
+    {
+        return [];
+    }
+
+    public function getRelationResources(): array
+    {
+        return [
+            ['relationName' => 'tags'],
+            ['relationName' => null],          // filtered out
+            ['relationName' => 'tags'],        // duplicate, deduped
+        ];
+    }
+}
+
+class QFResourceWithoutPanels extends BuildoraResource
+{
+    public static function modelClass(): string
+    {
+        return QFArticle::class;
+    }
+
+    public function defineFields(): array
+    {
+        return [];
+    }
+
+    public function getRelationResources(): array
+    {
+        return [];
+    }
+}
+
+/**
+ * QueryFactory exposes two intent-revealing entry points:
+ *   - forList()  : never eager-loads panel relations (datatable, exports)
+ *   - forDetail(): eager-loads everything declared via getRelationResources()
+ *
+ * These tests pin the routing: forList must NOT call with(), forDetail must
+ * call it with the deduplicated relation names.
+ */
+class QueryFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('qf_articles', function ($table) {
+            $table->increments('id');
+            $table->string('title')->nullable();
+        });
+
+        Schema::create('qf_tags', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('article_id');
+            $table->string('name')->nullable();
+        });
+    }
+
+    #[Test]
+    public function for_list_returns_a_buildora_query_builder(): void
+    {
+        $builder = QueryFactory::forList(new QFResourceWithPanels());
+
+        $this->assertInstanceOf(\Ginkelsoft\Buildora\BuildoraQueryBuilder::class, $builder);
+    }
+
+    #[Test]
+    public function for_list_does_not_eager_load_panel_relations(): void
+    {
+        $builder = QueryFactory::forList(new QFResourceWithPanels());
+        $eagerLoads = $builder->getEagerLoads();
+
+        $this->assertSame(
+            [],
+            array_keys($eagerLoads),
+            'forList() must not stage any with() calls — panels are not rendered on list views.'
+        );
+    }
+
+    #[Test]
+    public function for_detail_eager_loads_panel_relations(): void
+    {
+        $builder = QueryFactory::forDetail(new QFResourceWithPanels());
+        $eagerLoads = $builder->getEagerLoads();
+
+        $this->assertContains('tags', array_keys($eagerLoads));
+    }
+
+    #[Test]
+    public function for_detail_dedupes_and_filters_relation_names(): void
+    {
+        $builder = QueryFactory::forDetail(new QFResourceWithPanels());
+        $eagerLoads = $builder->getEagerLoads();
+
+        $tagsCount = count(array_filter(array_keys($eagerLoads), fn ($k) => $k === 'tags'));
+        $this->assertSame(1, $tagsCount);
+    }
+
+    #[Test]
+    public function for_detail_is_a_noop_when_resource_declares_no_panels(): void
+    {
+        $builder = QueryFactory::forDetail(new QFResourceWithoutPanels());
+        $eagerLoads = $builder->getEagerLoads();
+
+        $this->assertSame([], array_keys($eagerLoads));
+    }
+}


### PR DESCRIPTION
## Audit conclusie

De **list/detail split** is feitelijk al aanwezig — `QueryFactory::make()` accepteert een `\$eagerLoadRelations` boolean en `BuildoraResource::query()` vs `queryWithRelations()` routeren correct (list mode resp. detail mode). De performance-optimalisatie zit al in de codebase.

Het **API-gat**: `QueryFactory::make(\$r, true)` is een boolean trap. Een lezer kan zonder de factory te openen niet zien wat `true` doet.

## Wijziging

### Twee intent-revealing entry points

\`\`\`php
QueryFactory::forList(\$resource)    // geen panel eager-loads
QueryFactory::forDetail(\$resource)  // wel
\`\`\`

`make()` blijft als generieke constructor — de twee nieuwe methods zijn thin wrappers. Public API uitgebreid, niets gebroken.

### BuildoraResource gebruikt de nieuwe API

\`\`\`php
public static function query(): BuildoraQueryBuilder
{
    return QueryFactory::forList(new static());
}

public static function queryWithRelations(): BuildoraQueryBuilder
{
    return QueryFactory::forDetail(new static());
}
\`\`\`

Elke call site leest nu als een **statement of intent** in plaats van een magic boolean.

## Tests — 5 tests, sqlite-backed

- ✓ `forList()` returnt een `BuildoraQueryBuilder`
- ✓ `forList()` zet **geen** `with()` calls op (eagerLoads is leeg) — bewijst dat panel-relations worden overgeslagen
- ✓ `forDetail()` eager-loadt de gedeclareerde panel relations
- ✓ `forDetail()` dedupliceert en filtert null relation names
- ✓ `forDetail()` is een no-op als de resource geen panels declareert

Test stubs: `QFResourceWithPanels` en `QFResourceWithoutPanels` extenden `BuildoraResource` en gebruiken `modelClass()` static method (gerespecteerd door ModelResolver). Echte sqlite tabellen voor de QFArticle/QFTag relations.

## Backwards compatibility

- `QueryFactory::make()` is **niet** verwijderd — bestaande callers blijven werken
- `BuildoraResource::query()` en `queryWithRelations()` signatures zijn identiek
- Geen public API breaking changes

## Closes #129