### PR TITLE
refactor: DatatableRequest value object for shared request parsing (closes #140)

### DIFF
--- a/src/Http/Controllers/BuildoraDataTableController.php
+++ b/src/Http/Controllers/BuildoraDataTableController.php
@@ -3,6 +3,7 @@
 namespace Ginkelsoft\Buildora\Http\Controllers;
 
 use Ginkelsoft\Buildora\Datatable\BuildoraDatatable;
+use Ginkelsoft\Buildora\Http\Requests\DatatableRequest;
 use Ginkelsoft\Buildora\Support\ResourceResolver;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
@@ -36,16 +37,17 @@ class BuildoraDataTableController extends Controller
      */
     public function json(Request $request, string $resource): JsonResponse
     {
-        $search = (string) $request->input('search', '');
-        $sortBy = (string) $request->input('sortBy', '');
-        $sortDirection = (string) $request->input('sortDirection', 'asc');
-        $perPage = (int) $request->input('per_page', 10);
-        $page = (int) $request->input('page', 1);
-
+        $params = DatatableRequest::fromRequest($request);
         $datatable = new BuildoraDatatable($resource);
 
         return response()->json(
-            $datatable->getJsonResponse($search, $sortBy, $sortDirection, $perPage, $page)
+            $datatable->getJsonResponse(
+                $params->search,
+                $params->sortBy,
+                $params->sortDirection,
+                $params->perPage,
+                $params->page,
+            )
         );
     }
 }

--- a/src/Http/Requests/DatatableRequest.php
+++ b/src/Http/Requests/DatatableRequest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Http\Requests;
+
+use Illuminate\Http\Request;
+
+/**
+ * Value object that captures the four input parameters every Buildora
+ * datatable AJAX request carries.
+ *
+ * The controllers previously parsed these inline:
+ *
+ *   \$search = (string) \$request->input('search', '');
+ *   \$sortBy = (string) \$request->input('sortBy', '');
+ *   \$sortDirection = (string) \$request->input('sortDirection', 'asc');
+ *   \$perPage = (int) \$request->input('per_page', 10);
+ *   \$page = (int) \$request->input('page', 1);
+ *
+ * That worked, but skipped two defensive checks: sortDirection wasn't
+ * normalised (a crafted 'asc; DROP …' fell through to Eloquent's
+ * orderBy() which throws on invalid values — see #119), and perPage/page
+ * accepted zero / negative inputs that pagination then mishandled.
+ *
+ * Centralising the parsing means future controllers get the same
+ * sanitised inputs for free, and there is a single source of truth for
+ * what "a datatable request" means.
+ */
+final class DatatableRequest
+{
+    private const DEFAULT_PER_PAGE = 10;
+    private const MAX_PER_PAGE = 250;
+
+    public function __construct(
+        public readonly string $search,
+        public readonly string $sortBy,
+        public readonly string $sortDirection,
+        public readonly int $perPage,
+        public readonly int $page,
+    ) {
+    }
+
+    public static function fromRequest(Request $request): self
+    {
+        return new self(
+            search:        (string) $request->input('search', ''),
+            sortBy:        (string) $request->input('sortBy', ''),
+            sortDirection: self::normalizeSortDirection($request->input('sortDirection', 'asc')),
+            perPage:       self::clampPerPage((int) $request->input('per_page', self::DEFAULT_PER_PAGE)),
+            page:          max(1, (int) $request->input('page', 1)),
+        );
+    }
+
+    /**
+     * Strict "asc"|"desc". Anything else (crafted SQL fragment, typo, wrong
+     * type) falls back to "asc".
+     *
+     * NOTE: Buildora has a dedicated SortDirection helper that performs the
+     * same normalisation; this duplicate guard exists so DatatableRequest
+     * stays self-contained and doesn't add a cross-PR dependency. Consolidate
+     * once the helper lands on the same baseline.
+     */
+    private static function normalizeSortDirection(mixed $value): string
+    {
+        if (! is_string($value)) {
+            return 'asc';
+        }
+
+        $lower = strtolower(trim($value));
+
+        return $lower === 'desc' ? 'desc' : 'asc';
+    }
+
+    private static function clampPerPage(int $value): int
+    {
+        if ($value < 1) {
+            return self::DEFAULT_PER_PAGE;
+        }
+
+        if ($value > self::MAX_PER_PAGE) {
+            return self::MAX_PER_PAGE;
+        }
+
+        return $value;
+    }
+}

--- a/tests/Unit/Http/Requests/DatatableRequestTest.php
+++ b/tests/Unit/Http/Requests/DatatableRequestTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Http\Requests;
+
+use Ginkelsoft\Buildora\Http\Requests\DatatableRequest;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+
+class DatatableRequestTest extends TestCase
+{
+    private function requestWith(array $params): Request
+    {
+        return Request::create('/datatable', 'GET', $params);
+    }
+
+    #[Test]
+    public function defaults_are_applied_when_no_parameters_are_present(): void
+    {
+        $params = DatatableRequest::fromRequest($this->requestWith([]));
+
+        $this->assertSame('',     $params->search);
+        $this->assertSame('',     $params->sortBy);
+        $this->assertSame('asc',  $params->sortDirection);
+        $this->assertSame(10,     $params->perPage);
+        $this->assertSame(1,      $params->page);
+    }
+
+    #[Test]
+    public function legitimate_values_are_passed_through(): void
+    {
+        $params = DatatableRequest::fromRequest($this->requestWith([
+            'search'        => 'wietse',
+            'sortBy'        => 'name',
+            'sortDirection' => 'desc',
+            'per_page'      => 25,
+            'page'          => 3,
+        ]));
+
+        $this->assertSame('wietse', $params->search);
+        $this->assertSame('name',   $params->sortBy);
+        $this->assertSame('desc',   $params->sortDirection);
+        $this->assertSame(25,       $params->perPage);
+        $this->assertSame(3,        $params->page);
+    }
+
+    #[Test]
+    public function sort_direction_is_normalised_via_SortDirection_helper(): void
+    {
+        // Defence-in-depth: a crafted value should not propagate.
+        $params = DatatableRequest::fromRequest($this->requestWith([
+            'sortDirection' => 'asc; DROP TABLE users;--',
+        ]));
+
+        $this->assertSame('asc', $params->sortDirection);
+    }
+
+    #[Test]
+    public function sort_direction_casing_and_whitespace_are_handled(): void
+    {
+        $params = DatatableRequest::fromRequest($this->requestWith([
+            'sortDirection' => '  DESC  ',
+        ]));
+
+        $this->assertSame('desc', $params->sortDirection);
+    }
+
+    #[Test]
+    public function per_page_below_one_falls_back_to_default(): void
+    {
+        $a = DatatableRequest::fromRequest($this->requestWith(['per_page' => 0]));
+        $b = DatatableRequest::fromRequest($this->requestWith(['per_page' => -10]));
+
+        $this->assertSame(10, $a->perPage);
+        $this->assertSame(10, $b->perPage);
+    }
+
+    #[Test]
+    public function per_page_is_clamped_to_a_maximum(): void
+    {
+        $params = DatatableRequest::fromRequest($this->requestWith(['per_page' => 9999]));
+
+        $this->assertSame(250, $params->perPage);
+    }
+
+    #[Test]
+    public function page_is_clamped_to_at_least_one(): void
+    {
+        $a = DatatableRequest::fromRequest($this->requestWith(['page' => 0]));
+        $b = DatatableRequest::fromRequest($this->requestWith(['page' => -5]));
+
+        $this->assertSame(1, $a->page);
+        $this->assertSame(1, $b->page);
+    }
+
+    #[Test]
+    public function value_object_is_immutable(): void
+    {
+        $params = DatatableRequest::fromRequest($this->requestWith([]));
+
+        // Trying to mutate a readonly property must throw.
+        $this->expectException(\Error::class);
+        $params->search = 'mutated';
+    }
+}


### PR DESCRIPTION
## Audit conclusie

\`BuildoraDataTableController\` en \`RelationDatatableController\` delen minder logica dan mijn oorspronkelijke audit suggereerde: de tweede heeft een eigen relation-resolution flow (parent → relation → related resource) die niet veralgemeenbaar is. De **echte gedeelde grond** zit in **HTTP request parsing** — vijf params die elke datatable controller leest.

## Wijziging

### `src/Http/Requests/DatatableRequest.php` (nieuw)

Readonly value object met static factory:

\`\`\`php
\$params = DatatableRequest::fromRequest(\$request);
// → \$params->search, ->sortBy, ->sortDirection, ->perPage, ->page
\`\`\`

Centraliseert drie defensive checks die voorheen ad-hoc waren of ontbraken:

| Param | Sanitisation |
|---|---|
| `sortDirection` | strict `'asc'`/`'desc'`, case-insensitive, whitespace getrimd — alles anders (incl. crafted SQL fragments) → `'asc'` |
| `perPage` | < 1 → default (10), > 250 → 250 |
| `page` | `max(1, ...)` |

### Controller update

`BuildoraDataTableController::json()` wordt:

\`\`\`php
\$params = DatatableRequest::fromRequest(\$request);
\$datatable = new BuildoraDatatable(\$resource);

return response()->json(
    \$datatable->getJsonResponse(\$params->search, \$params->sortBy, \$params->sortDirection, \$params->perPage, \$params->page)
);
\`\`\`

## Tests — 8 tests, 18 asserties

- ✓ Defaults wanneer geen params aanwezig
- ✓ Legitieme values gaan door zonder mutation
- ✓ `sortDirection='asc; DROP TABLE users;--'` → `'asc'`
- ✓ Casing en whitespace gehandeld (`'  DESC  '` → `'desc'`)
- ✓ `per_page=0` en `per_page=-10` → 10 (default)
- ✓ `per_page=9999` → 250 (clamp)
- ✓ `page=0` en `page=-5` → 1
- ✓ Value object is immutable (readonly properties — mutation throws)

## Bekende duplicatie

`sortDirection` normalisatie zit ook in `Ginkelsoft\Buildora\Support\SortDirection` (PR #148 / issue #119). Bewust niet via die helper geroepen om deze PR onafhankelijk te houden van #148. Een kleine vervolg-PR kan ze samenvoegen zodra beide gemerged zijn.

## RelationDatatableController

Niet aangepast in deze PR. Die controller accepteert momenteel geen sort/filter/paginate params — search/sort op relation panels is een aparte feature. Wanneer dat geïmplementeerd wordt, kan dezelfde `DatatableRequest` worden gebruikt.

## Closes #140