### PR TITLE
feat(security): add scopeQuery() hook for record-level authorization (closes #123)

### DIFF
--- a/src/Resources/BuildoraResource.php
+++ b/src/Resources/BuildoraResource.php
@@ -247,6 +247,31 @@ abstract class BuildoraResource
     }
 
     /**
+     * Hook for scoping every Buildora-built query for this resource.
+     *
+     * The default returns the builder unchanged — Buildora keeps its current
+     * behaviour of surfacing every row a user with the resource's `*.view`
+     * permission has access to. Override in a subclass to enforce row-level
+     * authorization, multi-tenant separation, soft-deleted visibility, etc.
+     *
+     *   public function scopeQuery(Builder $query): Builder
+     *   {
+     *       return $query->where('owner_id', auth()->id());
+     *   }
+     *
+     * The scope is applied by QueryFactory for both list (query()) and
+     * detail (queryWithRelations()) contexts, so a user cannot bypass it by
+     * navigating to /resource/{id} directly — the model never resolves.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<Model> $query
+     * @return \Illuminate\Database\Eloquent\Builder<Model>
+     */
+    public function scopeQuery(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
+    {
+        return $query;
+    }
+
+    /**
      * Return the fully qualified model class name.
      *
      * @return string

--- a/src/Resources/QueryFactory.php
+++ b/src/Resources/QueryFactory.php
@@ -52,6 +52,11 @@ class QueryFactory
     {
         $query = $resource->getModelInstance()->newQuery();
 
+        // Apply the resource's authorization scope before any further
+        // composition. Defaults to a no-op; consumers override scopeQuery()
+        // to enforce row-level access (per-tenant, owner-only, etc.).
+        $query = $resource->scopeQuery($query);
+
         if ($eagerLoadRelations && method_exists($resource, 'getRelationResources')) {
             $relations = collect($resource->getRelationResources())
                 ->pluck('relationName')

--- a/tests/Unit/Resources/ScopeQueryTest.php
+++ b/tests/Unit/Resources/ScopeQueryTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Resources;
+
+use Ginkelsoft\Buildora\Resources\BuildoraResource;
+use Ginkelsoft\Buildora\Resources\QueryFactory;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use Ginkelsoft\Buildora\Traits\HasBuildora;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+
+class SQDocument extends Model
+{
+    use HasBuildora;
+
+    protected $table = 'sq_documents';
+    protected $guarded = [];
+    public $timestamps = false;
+}
+
+/**
+ * Stub resource with no scope override — must surface every row.
+ */
+class SQOpenResource extends BuildoraResource
+{
+    public static function modelClass(): string
+    {
+        return SQDocument::class;
+    }
+
+    public function defineFields(): array
+    {
+        return [];
+    }
+}
+
+/**
+ * Stub resource that restricts queries to documents owned by a hard-coded
+ * user id. Stand-in for the typical row-level auth pattern:
+ *   ->where('owner_id', auth()->id())
+ */
+class SQOwnerScopedResource extends BuildoraResource
+{
+    public const ALLOWED_OWNER = 7;
+
+    public static function modelClass(): string
+    {
+        return SQDocument::class;
+    }
+
+    public function defineFields(): array
+    {
+        return [];
+    }
+
+    public function scopeQuery(Builder $query): Builder
+    {
+        return $query->where('owner_id', self::ALLOWED_OWNER);
+    }
+}
+
+/**
+ * Pin the scopeQuery() hook contract:
+ *   - Default: no-op (BC for existing consumers).
+ *   - Override: SQL contains the scope's where clause, regardless of
+ *     list vs detail mode, and the query genuinely filters at the DB.
+ */
+class ScopeQueryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('sq_documents', function ($table) {
+            $table->increments('id');
+            $table->unsignedInteger('owner_id');
+            $table->string('title')->nullable();
+        });
+
+        SQDocument::create(['owner_id' => 7,  'title' => 'mine']);
+        SQDocument::create(['owner_id' => 7,  'title' => 'also mine']);
+        SQDocument::create(['owner_id' => 99, 'title' => 'someone else']);
+    }
+
+    #[Test]
+    public function default_scope_is_a_noop(): void
+    {
+        $sql = QueryFactory::make(new SQOpenResource())->toSql();
+
+        $this->assertStringNotContainsString('where', strtolower($sql));
+    }
+
+    #[Test]
+    public function override_adds_a_where_clause_to_list_queries(): void
+    {
+        $sql = QueryFactory::make(new SQOwnerScopedResource(), false)->toSql();
+
+        $this->assertStringContainsString('owner_id', $sql);
+    }
+
+    #[Test]
+    public function override_also_applies_in_detail_mode(): void
+    {
+        // The hook must run regardless of eager-loading. Otherwise a caller
+        // could bypass auth by hitting /resource/{id} (detail view).
+        $sql = QueryFactory::make(new SQOwnerScopedResource(), true)->toSql();
+
+        $this->assertStringContainsString('owner_id', $sql);
+    }
+
+    #[Test]
+    public function scope_actually_filters_rows_at_the_database(): void
+    {
+        $results = QueryFactory::make(new SQOwnerScopedResource())->get();
+
+        $this->assertCount(2, $results, 'Expected only the two rows owned by user 7.');
+    }
+
+    #[Test]
+    public function find_returns_null_for_records_outside_the_scope(): void
+    {
+        // Critical: a user with `*.view` cannot grab a record outside the
+        // scope by going straight to /resource/{id}. The model just doesn't
+        // resolve.
+        $unauthorised = SQDocument::where('owner_id', 99)->first();
+
+        $result = QueryFactory::make(new SQOwnerScopedResource())->find($unauthorised->id);
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
## Probleem

\`BuildoraResource\` autoriseerde alleen op **resource-niveau** via Spatie's \`{resource}.view\` permission. Een user die die permission had kon **elke** rij van het resource ophalen — directe URL (\`/buildora/user/{id}\`), datatable filter, relation panel. Klassieke IDOR.

Dit blokkeerde ook de echte fix voor #125 (BulkAction per-record auth).

## Oplossing — opt-in scope hook

Nieuwe methode op `BuildoraResource`:

\`\`\`php
public function scopeQuery(Builder \$query): Builder
{
    return \$query;  // default: no-op
}
\`\`\`

Consumers overriden in hun resource:

\`\`\`php
public function scopeQuery(Builder \$query): Builder
{
    return \$query->where('owner_id', auth()->id());
}
\`\`\`

### Toegepast vóór composite query bouw

`QueryFactory::make()` past de scope toe **voordat** het eager-loading of panel-relations doet. Dat betekent élke Buildora-built query — list (`query()`), detail (`queryWithRelations()`), export, panel datatable — gaat door dezelfde filter.

**Critical:** een user kan de filter niet omzeilen door direct naar \`/resource/{id}\` te navigeren. Het model resolved niet eens.

## Tests — 5 tests, sqlite-backed

1. ✓ Default `scopeQuery()` is een **no-op** — backwards compatible
2. ✓ Override met `where('owner_id', 7)` emit een SQL `WHERE` voor list queries
3. ✓ Zelfde `WHERE` verschijnt in **detail mode** — eager-load path bypassen kan niet
4. ✓ Database-niveau filter werkt: 2 van 3 seeded rows worden geretourneerd
5. ✓ **`find()` returnt `null`** voor records buiten de scope — de headline IDOR-prevention assertion

## Backwards compatibility

- Geen breaking changes: default returnt query ongewijzigd
- Bestaande resources werken zonder aanpassing
- Opt-in: alleen consumers die row-level auth nodig hebben overriden

## Volgvolgordes hierop

- **#125 (BulkAction auth)** kan nu opnieuw — bulk endpoints kunnen de scope toepassen op de geleverde IDs
- **#160 (relation N+1)** is geheel onafhankelijk
- Een dedicated Larastan extension zou `auth()` calls binnen `scopeQuery()` overrides kunnen valideren — vervolg-PR

## Documentatie

Docblock op `scopeQuery()` toont:
- Default gedrag
- Voorbeeld override
- Waar de hook in de query chain landt
- Waarom direct-ID-bypass niet werkt

## Closes #123