### PR TITLE
refactor: replace RowFormatter ViewField instanceof with polymorphic hook (closes #134)

### DIFF
--- a/src/Datatable/RowFormatter.php
+++ b/src/Datatable/RowFormatter.php
@@ -5,7 +5,6 @@ namespace Ginkelsoft\Buildora\Datatable;
 use Ginkelsoft\Buildora\Actions\RowAction;
 use Ginkelsoft\Buildora\Exceptions\BuildoraException;
 use Ginkelsoft\Buildora\Fields\Field;
-use Ginkelsoft\Buildora\Fields\Types\ViewField;
 
 class RowFormatter
 {
@@ -30,13 +29,11 @@ class RowFormatter
                 );
             }
 
-            if ($field instanceof ViewField) {
-                $view = view($field->getView(), [
-                    $field->getVarKey() => $field->value,
-                ])->render();
-
-                $field->value = $view;
-            }
+            // Field-type-specific format-time work goes here. The default
+            // implementation on Field is a no-op; only ViewField actually
+            // overrides this (to materialise its Blade partial). The
+            // formatter doesn't need to know which is which.
+            $field->renderForDisplay();
 
             $rawValue = $field->displayValue ?? $field->value;
 

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -208,6 +208,24 @@ class Field
     }
 
     /**
+     * Hook that runs once on each field before a datatable row is built.
+     *
+     * Lets a subclass do any field-type-specific work that has to happen
+     * at format time rather than at construction or value-fill time —
+     * most notably ViewField, which materialises its Blade partial into
+     * \$this->value here.
+     *
+     * Default: no-op. Subclasses override when needed; RowFormatter calls
+     * this on every field regardless of type, so we avoid the
+     * `if (\$field instanceof X) { ... }` chain in the formatter.
+     *
+     * @return void
+     */
+    public function renderForDisplay(): void
+    {
+    }
+
+    /**
      * Convert the field into an array representation.
      *
      * @return array<string, mixed>

--- a/src/Fields/Types/ViewField.php
+++ b/src/Fields/Types/ViewField.php
@@ -156,4 +156,19 @@ class ViewField extends Field
             $this->getVarKey() => $this->value,
         ])->render();
     }
+
+    /**
+     * Format-time hook used by RowFormatter. Renders the Blade partial
+     * with the field's current value and stores the resulting HTML back
+     * into ->value, so the rest of the formatter pipeline can treat it as
+     * any other displayable value.
+     *
+     * Overrides the no-op base implementation.
+     */
+    public function renderForDisplay(): void
+    {
+        $this->value = view($this->getView(), [
+            $this->getVarKey() => $this->value,
+        ])->render();
+    }
 }

--- a/tests/Unit/Datatable/RowFormatterPolymorphismTest.php
+++ b/tests/Unit/Datatable/RowFormatterPolymorphismTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Ginkelsoft\Buildora\Tests\Unit\Datatable;
+
+use Ginkelsoft\Buildora\Datatable\RowFormatter;
+use Ginkelsoft\Buildora\Fields\Types\TextField;
+use Ginkelsoft\Buildora\Fields\Types\ViewField;
+use Ginkelsoft\Buildora\Tests\TestCase;
+use Illuminate\Support\Facades\View;
+use PHPUnit\Framework\Attributes\Test;
+
+class RFPStubResource
+{
+    /** @var array<int, \Ginkelsoft\Buildora\Fields\Field> */
+    public array $fieldsToReturn = [];
+
+    public function getFields(): array
+    {
+        return $this->fieldsToReturn;
+    }
+
+    public function getRowActions(object $resource): array
+    {
+        return [];
+    }
+}
+
+/**
+ * Pins the OCP refactor: RowFormatter no longer branches on the concrete
+ * Field type to handle ViewField. It calls Field::renderForDisplay() on
+ * every field; the base implementation is a no-op, and ViewField overrides
+ * it to materialise its Blade partial.
+ *
+ * This is the surface area that #134 was about — adding a new
+ * "specialty" field type should never again require editing RowFormatter.
+ */
+class RowFormatterPolymorphismTest extends TestCase
+{
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        // Make a minimal inline view available so ViewField has something
+        // to render. Using a closure-backed Blade view keeps the test
+        // self-contained.
+        View::addNamespace('rfp', __DIR__ . '/views');
+    }
+
+    #[Test]
+    public function plain_field_renderForDisplay_is_a_noop(): void
+    {
+        $field = TextField::make('name');
+        $field->value = 'unchanged';
+
+        $field->renderForDisplay();
+
+        $this->assertSame('unchanged', $field->value);
+    }
+
+    #[Test]
+    public function view_field_renderForDisplay_materialises_the_partial(): void
+    {
+        // Build a one-off view file the field can render.
+        $viewDir = __DIR__ . '/views';
+        if (! is_dir($viewDir)) {
+            mkdir($viewDir, recursive: true);
+        }
+        $viewFile = $viewDir . '/echo.blade.php';
+        file_put_contents($viewFile, '<span>HELLO {{ $payload }}</span>');
+
+        try {
+            $field = ViewField::make('payload');
+            $field->view('rfp::echo');
+            $field->value = 'world';
+
+            $field->renderForDisplay();
+
+            $this->assertStringContainsString('HELLO', $field->value);
+            $this->assertStringContainsString('world', $field->value);
+        } finally {
+            @unlink($viewFile);
+        }
+    }
+
+    #[Test]
+    public function row_formatter_no_longer_references_concrete_field_types(): void
+    {
+        // Structural assertion: RowFormatter's source must not contain
+        // 'instanceof' followed by a concrete *Field type. The only
+        // remaining instanceof is the base Field type guard and the
+        // RowAction guard, both of which are interface-level.
+        $source = file_get_contents(__DIR__ . '/../../../src/Datatable/RowFormatter.php');
+
+        $this->assertStringNotContainsString('instanceof ViewField', $source);
+        $this->assertStringNotContainsString('instanceof TextField', $source);
+        $this->assertStringNotContainsString('instanceof BelongsToField', $source);
+        $this->assertStringNotContainsString('instanceof CurrencyField', $source);
+        $this->assertStringNotContainsString('instanceof BooleanField', $source);
+        $this->assertStringNotContainsString('instanceof SelectField', $source);
+    }
+}


### PR DESCRIPTION
## Probleem

Na PR #154 was er nog één instanceof-chain over in de datatable pipeline:

\`\`\`php
// src/Datatable/RowFormatter.php (vóór)
if (\$field instanceof ViewField) {
    \$view = view(\$field->getView(), [\$field->getVarKey() => \$field->value])->render();
    \$field->value = \$view;
}
\`\`\`

Een **textbook OCP-violation**, ook al is de chain kort: elke nieuwe field-type die format-time werk nodig heeft (preview generatie, signed URL, async fetch) zou aan deze conditional moeten worden toegevoegd. RowFormatter zou de details van élke field type leren kennen.

## Oplossing — polymorfe hook

`Field::renderForDisplay(): void` — een default no-op format-time hook. Subclasses overriden wanneer ze type-specifiek werk hebben:

\`\`\`php
// Field.php (base)
public function renderForDisplay(): void
{
    // no-op
}

// ViewField.php (override)
public function renderForDisplay(): void
{
    \$this->value = view(\$this->getView(), [
        \$this->getVarKey() => \$this->value,
    ])->render();
}
\`\`\`

`RowFormatter` weet niets meer van concrete field types:

\`\`\`php
foreach (\$resource->getFields() as \$field) {
    \$field->renderForDisplay();   // polymorf — no-op of view-render
    \$rawValue = \$field->displayValue ?? \$field->value;
    // ...
}
\`\`\`

`use ViewField` import is weg uit RowFormatter.

## Tests — 3 tests, 9 asserties

1. ✓ `TextField::renderForDisplay()` is een no-op (value blijft `'unchanged'`)
2. ✓ `ViewField::renderForDisplay()` rendert de Blade-partial in de `value` (gebruikt een temporary Blade view fixture)
3. ✓ **Structural assertion**: RowFormatter's source bevat geen `'instanceof ViewField'`, `'instanceof TextField'`, etc. Een toekomstige regressie die de instanceof-chain her-introduceert faalt deze test

## Vervolg

Andere field types die format-time werk hebben kunnen nu hun eigen `renderForDisplay()` toevoegen zonder de formatter aan te raken:
- BelongsToField met loaded relation (afhankelijk van #162)
- FileField met signed URL generatie
- AsyncBelongsToField met lazy fetch

Geen breaking change — bestaande field types werken precies hetzelfde.

## Closes #134